### PR TITLE
fix: Remove duplicate training sessions in training list

### DIFF
--- a/src/app/pages/training/trainings/trainings.page.ts
+++ b/src/app/pages/training/trainings/trainings.page.ts
@@ -335,7 +335,14 @@ export class TrainingsPage implements OnInit {
         ]).pipe(
           map(([teamMembersMap, teamsTrainings]) => {
             const flattenedTrainings = teamsTrainings.flat();
-            return flattenedTrainings.map((item) => {
+
+            // Remove duplicate trainings by ID
+            const uniqueTrainings = flattenedTrainings.filter(
+              (training, index, self) =>
+                index === self.findIndex((t) => t.training.id === training.training.id),
+            );
+
+            return uniqueTrainings.map((item) => {
               const teamMembers = teamMembersMap[item.teamId] || [];
               const validAttendees = item.attendees.filter(
                 (att) =>
@@ -533,7 +540,14 @@ export class TrainingsPage implements OnInit {
         ]).pipe(
           map(([teamMembersMap, teamsTrainings]) => {
             const flattenedTrainings = teamsTrainings.flat();
-            return flattenedTrainings.map((item) => {
+
+            // Remove duplicate trainings by ID
+            const uniqueTrainings = flattenedTrainings.filter(
+              (training, index, self) =>
+                index === self.findIndex((t) => t.training.id === training.training.id),
+            );
+
+            return uniqueTrainings.map((item) => {
               const teamMembers = teamMembersMap[item.teamId] || [];
               const validAttendees = item.attendees.filter(
                 (att) =>


### PR DESCRIPTION
Fixes #158

This PR fixes the issue where training sessions were displayed twice when accessed through Menu → My Teams → Team → Trainings.

## Changes
- Added deduplication logic to filter out duplicate trainings by ID
- Applied fix to both upcoming and past training methods
- Matches deduplication pattern used in teams processing

## Testing
- Duplicate training entries with same training-id should now appear only once
- Fixes the specific U13 training duplication issue reported

Generated with [Claude Code](https://claude.ai/code)