### PR TITLE
fix: Update notification icon to reflect unread status in News Header

### DIFF
--- a/src/app/pages/news/news/news.page.html
+++ b/src/app/pages/news/news/news.page.html
@@ -6,7 +6,15 @@
     <ion-title>{{"common.news" | translate}}</ion-title>
     <ion-buttons slot="end">
       <ion-button (click)="openNotification()">
-        <ion-icon slot="icon-only" name="notifications-outline"></ion-icon>
+        @if (notifications$ | async; as notifications) {
+          @if (notifications.length > 0) {
+            <ion-icon slot="icon-only" name="notifications"></ion-icon>
+          } @else {
+            <ion-icon slot="icon-only" name="notifications-outline"></ion-icon>
+          }
+        } @else {
+          <ion-icon slot="icon-only" name="notifications-outline"></ion-icon>
+        }
       </ion-button>
       <ion-button (click)="openFilter()">
         <ion-icon


### PR DESCRIPTION
The notification button in the News Header now dynamically displays:
- 'notifications' (filled icon) when there are unread notifications
- 'notifications-outline' (outline icon) when all notifications are read

This aligns with the icon behavior in notification.page.html and provides better visual feedback to users about their notification status.

Fixes #177