### PR TITLE
fix(lists): Skeleton-Hänger beheben & Lade-Logik der 5 Hauptscreens vereinheitlichen

### DIFF
--- a/src/app/pages/championship/championship/championship.page.ts
+++ b/src/app/pages/championship/championship/championship.page.ts
@@ -27,6 +27,7 @@ import {
   take,
   tap,
   shareReplay,
+  startWith,
 } from "rxjs";
 import { Game } from "src/app/models/game";
 import { AuthService } from "src/app/services/auth.service";
@@ -373,6 +374,16 @@ export class ChampionshipPage implements OnInit {
                           teamDetails,
                           teamId,
                         })),
+                        // Non-blocking enrichment: emit the row immediately with
+                        // empty attendees so the list renders at once instead of
+                        // gating on the slowest attendees read across all games.
+                        // Real counts/status fill in next.
+                        startWith({
+                          game,
+                          attendees: [],
+                          teamDetails: {},
+                          teamId: team.id,
+                        }),
                       ),
                     ),
                   );
@@ -560,6 +571,16 @@ export class ChampionshipPage implements OnInit {
                           teamDetails,
                           teamId,
                         })),
+                        // Non-blocking enrichment: emit the row immediately with
+                        // empty attendees so the list renders at once instead of
+                        // gating on the slowest attendees read across all games.
+                        // Real counts/status fill in next.
+                        startWith({
+                          game,
+                          attendees: [],
+                          teamDetails: {},
+                          teamId: team.id,
+                        }),
                       ),
                     ),
                   );

--- a/src/app/pages/championship/championship/championship.page.ts
+++ b/src/app/pages/championship/championship/championship.page.ts
@@ -111,8 +111,18 @@ export class ChampionshipPage implements OnInit {
   }
 
   private loadData() {
-    this.gameList$ = this.getTeamGamesUpcoming().pipe(shareReplay(1));
-    this.gameListPast$ = this.getTeamGamesPast().pipe(shareReplay(1));
+    // Build the realtime streams only once — see events.page.ts for the full
+    // rationale: rebuilding on every tab re-enter reflashed the skeleton and
+    // leaked Firestore listeners (and here also re-subscribed getCurrentSeason),
+    // which could leave the skeleton up forever on an empty list.
+    if (this.gameList$) return;
+
+    this.gameList$ = this.getTeamGamesUpcoming().pipe(
+      shareReplay({ bufferSize: 1, refCount: true }),
+    );
+    this.gameListPast$ = this.getTeamGamesPast().pipe(
+      shareReplay({ bufferSize: 1, refCount: true }),
+    );
 
     // Get dynamic season from Swiss Unihockey API
     this.swissUnihockeyService.getCurrentSeason().subscribe((season) => {

--- a/src/app/pages/championship/championship/championship.page.ts
+++ b/src/app/pages/championship/championship/championship.page.ts
@@ -142,12 +142,11 @@ export class ChampionshipPage implements OnInit {
       );
     });
 
-    this.teamAdminList$ = this.fbService
-      .getTeamAdminList()
-      .pipe(shareReplay(1));
-    this.clubAdminList$ = this.fbService
-      .getClubAdminList()
-      .pipe(shareReplay(1));
+    // getTeamAdminList()/getClubAdminList() share their listener internally via
+    // shareReplay, so no extra page-level shareReplay is needed (consistent with
+    // events/helfer/trainings).
+    this.teamAdminList$ = this.fbService.getTeamAdminList();
+    this.clubAdminList$ = this.fbService.getClubAdminList();
   }
 
   ngOnDestroy(): void {}

--- a/src/app/pages/event/events/events.page.ts
+++ b/src/app/pages/event/events/events.page.ts
@@ -19,6 +19,7 @@ import {
   mergeMap,
   of,
   shareReplay,
+  startWith,
   switchMap,
   take,
   tap,
@@ -275,6 +276,16 @@ export class EventsPage implements OnInit {
                               clubId: club.id,
                             }),
                           ),
+                          // Non-blocking enrichment: emit the row immediately
+                          // with empty attendees so the list renders at once
+                          // instead of gating on the slowest attendees read
+                          // across all events. Real counts fill in next.
+                          startWith({
+                            event,
+                            attendees: [],
+                            clubDetails,
+                            clubId: club.id,
+                          }),
                         ),
                     ),
                   );
@@ -442,6 +453,16 @@ export class EventsPage implements OnInit {
                               clubId: club.id,
                             }),
                           ),
+                          // Non-blocking enrichment: emit the row immediately
+                          // with empty attendees so the list renders at once
+                          // instead of gating on the slowest attendees read
+                          // across all events. Real counts fill in next.
+                          startWith({
+                            event,
+                            attendees: [],
+                            clubDetails,
+                            clubId: club.id,
+                          }),
                         ),
                     ),
                   );

--- a/src/app/pages/event/events/events.page.ts
+++ b/src/app/pages/event/events/events.page.ts
@@ -112,8 +112,21 @@ export class EventsPage implements OnInit {
   }
 
   private loadData() {
-    this.eventList$ = this.getClubEvent().pipe(shareReplay(1));
-    this.eventListPast$ = this.getClubEventPast().pipe(shareReplay(1));
+    // Build the realtime streams only once. They are live Firestore listeners
+    // that keep themselves up to date, so rebuilding them on every tab re-enter
+    // is unnecessary — and harmful: each rebuild reset the async pipe to null
+    // (skeleton reflash) and, with refCount:false, leaked the previous snapshot
+    // listeners. On an empty list the freshly attached listener then competed
+    // with the leaked ones and its initial empty snapshot could stall, leaving
+    // the skeleton up forever. Guarding here fixes both.
+    if (this.eventList$) return;
+
+    this.eventList$ = this.getClubEvent().pipe(
+      shareReplay({ bufferSize: 1, refCount: true }),
+    );
+    this.eventListPast$ = this.getClubEventPast().pipe(
+      shareReplay({ bufferSize: 1, refCount: true }),
+    );
 
     //Create Events, Helfer, News
     this.clubAdminList$ = this.fbService.getClubAdminList();

--- a/src/app/pages/helfer/helfer/helfer.page.ts
+++ b/src/app/pages/helfer/helfer/helfer.page.ts
@@ -85,8 +85,18 @@ export class HelferPage implements OnInit {
   }
 
   private loadData() {
-    this.helferList$ = this.getHelferEvent().pipe(shareReplay(1));
-    this.helferListPast$ = this.getHelferEventPast().pipe(shareReplay(1));
+    // Build the realtime streams only once — see events.page.ts for the full
+    // rationale: rebuilding on every tab re-enter reflashed the skeleton and
+    // leaked Firestore listeners, which could leave the skeleton up forever on
+    // an empty list.
+    if (this.helferList$) return;
+
+    this.helferList$ = this.getHelferEvent().pipe(
+      shareReplay({ bufferSize: 1, refCount: true }),
+    );
+    this.helferListPast$ = this.getHelferEventPast().pipe(
+      shareReplay({ bufferSize: 1, refCount: true }),
+    );
 
     //Create Events, Helfer, News
     this.clubAdminList$ = this.fbService.getClubAdminList();

--- a/src/app/pages/helfer/helfer/helfer.page.ts
+++ b/src/app/pages/helfer/helfer/helfer.page.ts
@@ -18,6 +18,7 @@ import {
   mergeMap,
   of,
   shareReplay,
+  startWith,
   switchMap,
   take,
   tap,
@@ -270,6 +271,19 @@ export class HelferPage implements OnInit {
                             countNeeded: 0,
                           }),
                         ),
+                        // Non-blocking enrichment: emit the event row at once
+                        // with placeholder counts. The Schichten/attendees reads
+                        // are nested 3 levels deep, so combineLatest otherwise
+                        // gates the whole list on the slowest leaf read across
+                        // all events — which also starved the (empty) upcoming
+                        // list of connection capacity, leaving its skeleton up.
+                        // Real Schichten/counts fill in on the next emission.
+                        startWith({
+                          ...event,
+                          schichten: [],
+                          countAttendees: 0,
+                          countNeeded: 0,
+                        }),
                       ),
                   ),
                 );
@@ -413,6 +427,19 @@ export class HelferPage implements OnInit {
                             countNeeded: 0,
                           }),
                         ),
+                        // Non-blocking enrichment: emit the event row at once
+                        // with placeholder counts. The Schichten/attendees reads
+                        // are nested 3 levels deep, so combineLatest otherwise
+                        // gates the whole list on the slowest leaf read across
+                        // all events — which also starved the (empty) upcoming
+                        // list of connection capacity, leaving its skeleton up.
+                        // Real Schichten/counts fill in on the next emission.
+                        startWith({
+                          ...event,
+                          schichten: [],
+                          countAttendees: 0,
+                          countNeeded: 0,
+                        }),
                       ),
                   ),
                 );

--- a/src/app/pages/news/news/news.page.ts
+++ b/src/app/pages/news/news/news.page.ts
@@ -185,7 +185,15 @@ export class NewsPage implements OnInit {
   }
 
   private loadData() {
-    this.newsList$ = this.getNews().pipe(shareReplay(1));
+    // Build the realtime streams only once — see events.page.ts for the full
+    // rationale: rebuilding on every tab re-enter reflashed the skeleton and
+    // leaked Firestore listeners, which could leave the skeleton up forever on
+    // an empty list.
+    if (this.newsList$) return;
+
+    this.newsList$ = this.getNews().pipe(
+      shareReplay({ bufferSize: 1, refCount: true }),
+    );
     this.filteredNewsList$ = combineLatest([
       this.newsList$ as Observable<
         (News & { source?: "verein" | "verband" })[]
@@ -197,12 +205,18 @@ export class NewsPage implements OnInit {
         return list.filter((n) => n.source === filter);
       }),
     );
-    this.notifications$ = this.getNotifications().pipe(shareReplay(1));
+    this.notifications$ = this.getNotifications().pipe(
+      shareReplay({ bufferSize: 1, refCount: true }),
+    );
     this.clubAdminList$ = this.fbService
       .getClubAdminList()
-      .pipe(shareReplay(1));
-    this.clubList$ = this.fbService.getClubList().pipe(shareReplay(1));
-    this.clubGames$ = this.getClubGames().pipe(shareReplay(1));
+      .pipe(shareReplay({ bufferSize: 1, refCount: true }));
+    this.clubList$ = this.fbService
+      .getClubList()
+      .pipe(shareReplay({ bufferSize: 1, refCount: true }));
+    this.clubGames$ = this.getClubGames().pipe(
+      shareReplay({ bufferSize: 1, refCount: true }),
+    );
 
     // Prüfe ob der Benutzer in einem Club mit aktiviertem Meisterschaftsmodul ist
     this.clubList$.pipe(take(1)).subscribe((clubList) => {

--- a/src/app/pages/news/news/news.page.ts
+++ b/src/app/pages/news/news/news.page.ts
@@ -208,9 +208,11 @@ export class NewsPage implements OnInit {
     this.notifications$ = this.getNotifications().pipe(
       shareReplay({ bufferSize: 1, refCount: true }),
     );
-    this.clubAdminList$ = this.fbService
-      .getClubAdminList()
-      .pipe(shareReplay({ bufferSize: 1, refCount: true }));
+    // getClubAdminList() shares its listener internally via shareReplay, so no
+    // extra page-level shareReplay is needed (consistent with the other pages).
+    // getClubList() does NOT, so it keeps a page-level shareReplay to share the
+    // single listener across the template + the take(1) check below.
+    this.clubAdminList$ = this.fbService.getClubAdminList();
     this.clubList$ = this.fbService
       .getClubList()
       .pipe(shareReplay({ bufferSize: 1, refCount: true }));

--- a/src/app/pages/training/trainings/trainings.page.ts
+++ b/src/app/pages/training/trainings/trainings.page.ts
@@ -17,6 +17,7 @@ import {
   mergeMap,
   of,
   shareReplay,
+  startWith,
   switchMap,
   take,
   tap,
@@ -548,6 +549,20 @@ export class TrainingsPage implements OnInit {
                               teamId,
                             }),
                           ),
+                          // Non-blocking enrichment: emit the row immediately
+                          // with placeholder counts so the past list renders at
+                          // once. Without this, combineLatest gates the whole
+                          // list on the slowest attendees/exercises read across
+                          // up to 30 trainings, so rows appeared only "much
+                          // later". The real counts/badges fill in on the next
+                          // emission.
+                          startWith({
+                            training,
+                            attendees: [],
+                            exercises: [],
+                            teamDetails: {},
+                            teamId: team.id,
+                          }),
                         ),
                       ),
                     );

--- a/src/app/pages/training/trainings/trainings.page.ts
+++ b/src/app/pages/training/trainings/trainings.page.ts
@@ -133,9 +133,19 @@ export class TrainingsPage implements OnInit {
   }
 
   private loadData() {
+    // Build the realtime streams only once — see events.page.ts for the full
+    // rationale: rebuilding on every tab re-enter reflashed the skeleton and
+    // leaked Firestore listeners, which could leave the skeleton up forever on
+    // an empty list.
+    if (this.trainingList$) return;
+
     // DATA
-    this.trainingList$ = this.getTeamTraining().pipe(shareReplay(1));
-    this.trainingListPast$ = this.getTeamTrainingPast().pipe(shareReplay(1));
+    this.trainingList$ = this.getTeamTraining().pipe(
+      shareReplay({ bufferSize: 1, refCount: true }),
+    );
+    this.trainingListPast$ = this.getTeamTrainingPast().pipe(
+      shareReplay({ bufferSize: 1, refCount: true }),
+    );
     // CREATE
     this.teamAdminList$ = this.fbService.getTeamAdminList();
   }

--- a/src/app/pages/training/trainings/trainings.page.ts
+++ b/src/app/pages/training/trainings/trainings.page.ts
@@ -333,6 +333,17 @@ export class TrainingsPage implements OnInit {
                           teamDetails,
                           teamId,
                         })),
+                        // Non-blocking enrichment: emit the row immediately with
+                        // placeholder counts so the list renders at once instead
+                        // of gating on the slowest attendees/exercises read.
+                        // Real counts/status fill in next.
+                        startWith({
+                          training,
+                          attendees: [],
+                          exercises: [],
+                          teamDetails: {},
+                          teamId: team.id,
+                        }),
                       ),
                     ),
                   );


### PR DESCRIPTION
## Problem

Auf den fünf Hauptscreens (News, Trainings, Championship, Events, Helfer) gab es mehrere Lade-Probleme, besonders auf iOS:

1. **Tab-Wechsel:** Skeleton erschien erneut und Daten wurden neu geladen.
2. **Leere Listen:** Das Skeleton verschwand nie, obwohl es keine Einträge gibt (kommend wie vergangen).
3. **Vergangene Listen:** Erschienen „erst ganz viel später"; bei Helfer blockierte der Fan-out sogar die leere kommende Liste.

## Ursachen

- `loadData()` lief in `ngOnInit` **und** `ionViewWillEnter`, baute also bei **jedem** Tab-Wechsel neue Observables. Jeder Rebuild setzte die `async`-Pipe auf `null` (Skeleton-Reflash) und leakte mit `shareReplay(1)` (refCount:false) die alten Firestore-Listener.
- Die Listen reicherten **jeden** Eintrag über `combineLatest` mit Teilnehmern/Übungen/Schichten/Team-Ref an. `combineLatest` emittiert erst, wenn **alle** Sub-Reads (bis zu 30 Einträge × N) ihren ersten Snapshot geliefert haben → der langsamste Read blockierte die ganze Liste und sättigte die Verbindung.

## Änderungen

- **Streams nur einmal aufbauen** (Guard in `loadData`) + `shareReplay({ bufferSize: 1, refCount: true })` → kein Reflash/Leak mehr, leere Listen lösen sich zuverlässig zur „keine Daten"-Notiz auf.
- **Non-blocking Enrichment via `startWith`**: jede Zeile emittiert sofort eine Platzhalter-Version (leere Teilnehmer/Schichten, Zähler 0); Name/Datum/Ort erscheinen auf einen Schlag, Zähler/Badges füllen sich nach. Angewendet auf kommende **und** vergangene Liste bei Trainings, Championship, Events, Helfer.
- **Konsistenz:** Alle 5 Screens nutzen nun denselben Aufbau (einmaliger Build, refCount:true). Redundante Page-Level-`shareReplay` auf den Admin-Listen entfernt (Service shareReplay'd bereits intern); `clubList$` in News behält seinen Pipe (Service hat kein internes shareReplay).

News bleibt bewusst ohne `startWith` — es hat nur einen leichten Fan-out pro Club (1–3) und eine aggregierte Liste, lädt also bereits schnell.

## Test

- `tsc --noEmit` grün, lint-staged grün.
- Manuell auf dem iPhone zu prüfen: Kaltstart + Tab-Wechsel auf allen 5 Screens; leere kommende/vergangene Listen; Screens mit vielen vergangenen Einträgen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)