### PR TITLE
feat(news): Filter nach einzelnen Vereinen statt generischer Verein-Option

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -50,7 +50,15 @@
       "Read(//opt/homebrew/Cellar/gh/2.92.0/bin/**)",
       "Bash(ssh -T -o BatchMode=yes -o ConnectTimeout=5 git@github.com)",
       "Bash(ls ~/.nvm/versions/node 2>/dev/null; which -a node npx 2>/dev/null; ls /opt/homebrew/bin/npx /usr/local/bin/npx 2>/dev/null)",
-      "Read(//usr/local/lib/node_modules/npx/**)"
+      "Read(//usr/local/lib/node_modules/npx/**)",
+      "Bash(gh api *)",
+      "Bash(mdfind -name \"venova\")",
+      "WebFetch(domain:registry.npmjs.org)",
+      "Bash(~/.nvm/versions/node/v22.21.1/bin/node --version)",
+      "Bash(command -v node)",
+      "Bash(/usr/local/bin/node node_modules/.bin/tsc --noEmit -p tsconfig.app.json)",
+      "Bash(echo \"EXIT: $?\")",
+      "Bash(./node_modules/.bin/tsc --noEmit -p tsconfig.json)"
     ],
     "additionalDirectories": ["/Users/sandro"]
   },

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "app.myclub.defaultapp"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 235
-        versionName "2.5.0"
+        versionCode 236
+        versionName "2.5.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
             ignoreAssetsPattern '!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~'

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -389,7 +389,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = App/AppRelease.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 235;
+				CURRENT_PROJECT_VERSION = 236;
 				INFOPLIST_FILE = App/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = myclub;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.sports";
@@ -398,7 +398,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.5.0;
+				MARKETING_VERSION = 2.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = app.myclub.default;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "myclub",
-  "version": "2.5.0",
-  "buildNumber": "235",
+  "version": "2.5.1",
+  "buildNumber": "236",
   "author": "liitu consulting gmbh",
   "homepage": "https://my-club.app/",
   "scripts": {

--- a/project-summary.md
+++ b/project-summary.md
@@ -1,97 +1,96 @@
 ## Capacitor Plugins
 
-- 🟧 [@capacitor/app@7.1.0](https://github.com/ionic-team/capacitor-plugins.git) - (Latest 8.0.0) - Is behind 1 major version.
-- 🟧 [@capacitor/browser@7.0.2](https://github.com/ionic-team/capacitor-plugins.git) - (Latest 8.0.0) - Is behind 1 major version.
-- 🟧 [@capacitor/camera@7.0.2](https://github.com/ionic-team/capacitor-plugins.git) - (Latest 8.0.0) - Is behind 1 major version.
-- 🟧 [@capacitor/clipboard@7.0.2](https://github.com/ionic-team/capacitor-plugins.git) - (Latest 8.0.0) - Is behind 1 major version.
-- 🟧 [@capacitor/device@7.0.2](https://github.com/ionic-team/capacitor-plugins.git) - (Latest 8.0.0) - Is behind 1 major version.
-- 🟧 [@capacitor/dialog@7.0.2](https://github.com/ionic-team/capacitor-plugins.git) - (Latest 8.0.0) - Is behind 1 major version.
-- 🟧 [@capacitor/filesystem@7.1.4](https://github.com/ionic-team/capacitor-filesystem.git) - (Latest 8.0.0) - Is behind 1 major version.
-- 🟧 [@capacitor/geolocation@7.1.5](https://github.com/ionic-team/capacitor-geolocation.git) - (Latest 8.0.0) - Is behind 1 major version.
-- 🟧 [@capacitor/google-maps@7.2.0](https://github.com/ionic-team/capacitor-google-maps.git) - (Latest 8.0.0) - Is behind 1 major version.
-- 🟧 [@capacitor/haptics@7.0.2](https://github.com/ionic-team/capacitor-haptics.git) - (Latest 8.0.0) - Is behind 1 major version.
-- 🟧 [@capacitor/keyboard@7.0.3](https://github.com/ionic-team/capacitor-keyboard.git) - (Latest 8.0.0) - Is behind 1 major version.
-- 🟧 [@capacitor/network@7.0.2](https://github.com/ionic-team/capacitor-plugins.git) - (Latest 8.0.0) - Is behind 1 major version.
-- 🟧 [@capacitor/preferences@7.0.2](https://github.com/ionic-team/capacitor-plugins.git) - (Latest 8.0.0) - Is behind 1 major version.
-- 🟧 [@capacitor/push-notifications@7.0.3](https://github.com/ionic-team/capacitor-plugins.git) - (Latest 8.0.0) - Is behind 1 major version.
-- 🟧 [@capacitor/share@7.0.2](https://github.com/ionic-team/capacitor-plugins.git) - (Latest 8.0.0) - Is behind 1 major version.
-- 🟧 [@capacitor/splash-screen@7.0.3](https://github.com/ionic-team/capacitor-plugins.git) - (Latest 8.0.0) - Is behind 1 major version.
-- 🟧 [@capacitor/status-bar@7.0.3](https://github.com/ionic-team/capacitor-plugins.git) - (Latest 8.0.0) - Is behind 1 major version.
-- 🟧 [@capawesome/capacitor-android-edge-to-edge-support@7.2.3](https://github.com/capawesome-team/capacitor-plugins.git) - (Latest 8.0.2) - Is behind 1 major version.
-- 🟧 [capacitor-plugin-safe-area@4.0.3](https://github.com/AlwaysLoveme/capacitor-plugin-safe-area.git.git) - (Latest 5.0.0) - Is behind 1 major version.
+- 🟩 [@capacitor/app@8.1.0](https://github.com/ionic-team/capacitor-plugins.git)
+- 🟩 [@capacitor/browser@8.0.3](https://github.com/ionic-team/capacitor-plugins.git)
+- 🟩 [@capacitor/camera@8.2.0](https://github.com/ionic-team/capacitor-camera.git)
+- 🟩 [@capacitor/clipboard@8.0.1](https://github.com/ionic-team/capacitor-plugins.git)
+- 🟩 [@capacitor/device@8.0.2](https://github.com/ionic-team/capacitor-plugins.git)
+- 🟩 [@capacitor/dialog@8.0.1](https://github.com/ionic-team/capacitor-plugins.git)
+- 🟩 [@capacitor/filesystem@8.1.2](https://github.com/ionic-team/capacitor-filesystem.git)
+- 🟩 [@capacitor/geolocation@8.2.0](https://github.com/ionic-team/capacitor-geolocation.git)
+- 🟩 [@capacitor/haptics@8.0.2](https://github.com/ionic-team/capacitor-haptics.git)
+- 🟩 [@capacitor/keyboard@8.0.5](https://github.com/ionic-team/capacitor-keyboard.git)
+- 🟩 [@capacitor/network@8.0.1](https://github.com/ionic-team/capacitor-plugins.git)
+- 🟩 [@capacitor/preferences@8.0.1](https://github.com/ionic-team/capacitor-plugins.git)
+- 🟩 [@capacitor/push-notifications@8.1.1](https://github.com/ionic-team/capacitor-plugins.git)
+- 🟩 [@capacitor/share@8.0.1](https://github.com/ionic-team/capacitor-plugins.git)
+- 🟩 [@capacitor/splash-screen@8.0.1](https://github.com/ionic-team/capacitor-plugins.git)
+- 🟩 [@capacitor/status-bar@8.0.2](https://github.com/ionic-team/capacitor-plugins.git)
+- 🟩 [@capawesome/capacitor-android-edge-to-edge-support@8.0.6](https://github.com/capawesome-team/capacitor-plugins.git) - (Latest 8.0.8)
+- 🟩 [capacitor-plugin-safe-area@5.0.0](https://github.com/AlwaysLoveme/capacitor-plugin-safe-area.git.git)
 
 ## Cordova Plugins
 
-- 🟥 [cordova-plugin-ionic@5.5.3](https://github.com/ionic-team/cordova-plugin-ionic.git) - Unmaintained (3.4 years since last release)
-
 ## Dependencies
 
-- 🟩 [@angular-devkit/build-angular@21.0.5](https://github.com/angular/angular-cli.git)
-- 🟩 [@angular-eslint/builder@21.1.0](https://github.com/angular-eslint/angular-eslint.git)
-- 🟩 [@angular-eslint/eslint-plugin@21.1.0](https://github.com/angular-eslint/angular-eslint.git)
-- 🟩 [@angular-eslint/eslint-plugin-template@21.1.0](https://github.com/angular-eslint/angular-eslint.git)
-- 🟩 [@angular-eslint/schematics@21.1.0](https://github.com/angular-eslint/angular-eslint.git)
-- 🟩 [@angular-eslint/template-parser@21.1.0](https://github.com/angular-eslint/angular-eslint.git)
-- 🟩 [@angular/build@21.0.5](https://github.com/angular/angular-cli.git)
-- 🟩 [@angular/cli@21.0.5](https://github.com/angular/angular-cli.git)
-- 🟩 [@angular/common@21.0.8](https://github.com/angular/angular.git)
-- 🟩 [@angular/compiler@21.0.8](https://github.com/angular/angular.git)
-- 🟩 [@angular/compiler-cli@21.0.8](https://github.com/angular/angular.git)
-- 🟩 [@angular/core@21.0.8](https://github.com/angular/angular.git)
+- 🟩 [@angular-devkit/build-angular@21.2.16](https://github.com/angular/angular-cli.git)
+- 🟧 [@angular-eslint/builder@21.4.0](https://github.com/angular-eslint/angular-eslint.git) - (Latest 22.0.0) - Is behind 1 major version.
+- 🟧 [@angular-eslint/eslint-plugin@21.4.0](https://github.com/angular-eslint/angular-eslint.git) - (Latest 22.0.0) - Is behind 1 major version.
+- 🟧 [@angular-eslint/eslint-plugin-template@21.4.0](https://github.com/angular-eslint/angular-eslint.git) - (Latest 22.0.0) - Is behind 1 major version.
+- 🟧 [@angular-eslint/schematics@21.4.0](https://github.com/angular-eslint/angular-eslint.git) - (Latest 22.0.0) - Is behind 1 major version.
+- 🟧 [@angular-eslint/template-parser@21.4.0](https://github.com/angular-eslint/angular-eslint.git) - (Latest 22.0.0) - Is behind 1 major version.
+- 🟩 [@angular/build@21.2.16](https://github.com/angular/angular-cli.git)
+- 🟩 [@angular/cli@21.2.16](https://github.com/angular/angular-cli.git)
+- 🟩 [@angular/common@21.2.17](https://github.com/angular/angular.git)
+- 🟩 [@angular/compiler@21.2.17](https://github.com/angular/angular.git)
+- 🟩 [@angular/compiler-cli@21.2.17](https://github.com/angular/angular.git)
+- 🟩 [@angular/core@21.2.17](https://github.com/angular/angular.git)
 - 🟩 [@angular/fire@20.0.1](https://github.com/angular/angularfire.git)
-- 🟩 [@angular/forms@21.0.8](https://github.com/angular/angular.git)
-- 🟩 [@angular/localize@21.0.8](https://github.com/angular/angular.git)
-- 🟩 [@angular/platform-browser@21.0.8](https://github.com/angular/angular.git)
-- 🟩 [@angular/platform-browser-dynamic@21.0.8](https://github.com/angular/angular.git)
-- 🟩 [@angular/router@21.0.8](https://github.com/angular/angular.git)
-- 🟩 [@angular/service-worker@21.0.8](https://github.com/angular/angular.git)
-- 🟧 [@capacitor/android@7.4.4](https://github.com/ionic-team/capacitor.git) - (Latest 8.0.1) - Is behind 1 major version.
-- 🟧 [@capacitor/assets@3.0.5](https://github.com/ionic-team/capacitor-assets.git) - May be unmaintained (1.9 years since last release)
-- 🟧 [@capacitor/cli@7.4.4](https://github.com/ionic-team/capacitor.git) - (Latest 8.0.1) - Is behind 1 major version.
-- 🟧 [@capacitor/core@7.4.4](https://github.com/ionic-team/capacitor.git) - (Latest 8.0.1) - Is behind 1 major version.
-- 🟧 [@capacitor/ios@7.4.4](https://github.com/ionic-team/capacitor.git) - (Latest 8.0.1) - Is behind 1 major version.
-- 🟧 [@fortawesome/angular-fontawesome@1.0.0](https://github.com/FortAwesome/angular-fontawesome.git) - (Latest 4.0.0) - Is behind 3 major versions.
-- 🟧 [@fortawesome/fontawesome-svg-core@6.7.2](https://github.com/FortAwesome/Font-Awesome.git) - (Latest 7.1.0) - Is behind 1 major version.
-- 🟧 [@fortawesome/free-brands-svg-icons@6.7.2](https://github.com/FortAwesome/Font-Awesome.git) - (Latest 7.1.0) - Is behind 1 major version.
-- 🟧 [@fortawesome/free-solid-svg-icons@6.7.2](https://github.com/FortAwesome/Font-Awesome.git) - (Latest 7.1.0) - Is behind 1 major version.
-- 🟩 [@ionic/angular@8.7.16](https://github.com/ionic-team/ionic-framework.git)
-- 🟩 [@ionic/angular-server@8.7.16](https://github.com/ionic-team/ionic-framework.git)
+- 🟩 [@angular/forms@21.2.17](https://github.com/angular/angular.git)
+- 🟩 [@angular/localize@21.2.17](https://github.com/angular/angular.git)
+- 🟩 [@angular/platform-browser@21.2.17](https://github.com/angular/angular.git)
+- 🟩 [@angular/router@21.2.17](https://github.com/angular/angular.git)
+- 🟩 [@angular/service-worker@21.2.17](https://github.com/angular/angular.git)
+- 🟩 [@capacitor/android@8.4.1](https://github.com/ionic-team/capacitor.git)
+- 🟥 [@capacitor/assets@3.0.5](https://github.com/ionic-team/capacitor-assets.git) - Unmaintained (2.2 years since last release)
+- 🟩 [@capacitor/cli@8.4.1](https://github.com/ionic-team/capacitor.git)
+- 🟩 [@capacitor/core@8.4.1](https://github.com/ionic-team/capacitor.git)
+- 🟩 [@capacitor/ios@8.4.1](https://github.com/ionic-team/capacitor.git)
+- 🟧 [@fortawesome/angular-fontawesome@4.0.0](https://github.com/FortAwesome/angular-fontawesome.git) - (Latest 5.0.0) - Is behind 1 major version.
+- 🟧 [@fortawesome/fontawesome-svg-core@6.7.2](https://github.com/FortAwesome/Font-Awesome.git) - (Latest 7.2.0) - Is behind 1 major version.
+- 🟧 [@fortawesome/free-brands-svg-icons@6.7.2](https://github.com/FortAwesome/Font-Awesome.git) - (Latest 7.2.0) - Is behind 1 major version.
+- 🟧 [@fortawesome/free-solid-svg-icons@6.7.2](https://github.com/FortAwesome/Font-Awesome.git) - (Latest 7.2.0) - Is behind 1 major version.
+- 🟩 [@ionic/angular@8.8.11](https://github.com/ionic-team/ionic-framework.git)
+- 🟩 [@ionic/angular-server@8.8.11](https://github.com/ionic-team/ionic-framework.git)
 - 🟩 [@ionic/angular-toolkit@12.3.0](https://github.com/ionic-team/angular-toolkit.git)
-- 🟩 [@ionic/cli@7.2.1](https://github.com/ionic-team/ionic-cli.git)
-- 🟥 [@ionic/lab@3.2.15](https://github.com/ionic-team/ionic-cli.git) - Unmaintained (3.1 years since last release)
-- 🟧 [@ionic/pwa-elements@3.3.0](https://github.com/ionic-team/ionic-pwa-elements.git) - May be unmaintained (1.7 years since last release)
-- 🟧 [@ngx-translate/core@16.0.4](https://github.com/ngx-translate/core.git) - (Latest 17.0.0) - Is behind 1 major version.
-- 🟧 @ngx-translate/http-loader@16.0.1 - (Latest 17.0.0) - Is behind 1 major version.
-- 🟧 [@types/jasmine@4.6.4](https://github.com/DefinitelyTyped/DefinitelyTyped.git) - (Latest 5.1.15) - Is behind 1 major version.
-- 🟥 [@types/jasminewd2@2.0.13](https://github.com/DefinitelyTyped/DefinitelyTyped.git) - Unmaintained (2.2 years since last release)
-- 🟧 [@types/node@20.11.30](https://github.com/DefinitelyTyped/DefinitelyTyped.git) - (Latest 25.0.8) - Is behind 5 major versions.
-- 🟩 [@types/pdfkit@0.14.0](https://github.com/DefinitelyTyped/DefinitelyTyped.git) - (Latest 0.17.4)
-- 🟩 [firebase@12.4.0](https://github.com/firebase/firebase-js-sdk.git) - (Latest 12.7.0)
+- 🟧 [@ionic/cli@7.2.1](https://github.com/ionic-team/ionic-cli.git) - May be unmaintained (1.3 years since last release)
+- 🟥 [@ionic/lab@3.2.15](https://github.com/ionic-team/ionic-cli.git) - Unmaintained (3.5 years since last release)
+- 🟩 [@ionic/pwa-elements@3.4.0](https://github.com/ionic-team/ionic-pwa-elements.git)
+- 🟩 [@maplibre/ngx-maplibre-gl@21.0.2](https://github.com/maplibre/ngx-maplibre-gl.git)
+- 🟧 [@ngx-translate/core@16.0.4](https://github.com/ngx-translate/core.git) - (Latest 18.0.0) - Is behind 2 major versions.
+- 🟧 @ngx-translate/http-loader@16.0.1 - (Latest 18.0.0) - Is behind 2 major versions.
+- 🟧 [@types/jasmine@4.6.4](https://github.com/DefinitelyTyped/DefinitelyTyped.git) - (Latest 6.0.0) - Is behind 2 major versions.
+- 🟥 [@types/jasminewd2@2.0.13](https://github.com/DefinitelyTyped/DefinitelyTyped.git) - Unmaintained (2.6 years since last release)
+- 🟧 [@types/node@20.11.30](https://github.com/DefinitelyTyped/DefinitelyTyped.git) - (Latest 26.0.0) - Is behind 6 major versions.
+- 🟩 [@types/pdfkit@0.14.0](https://github.com/DefinitelyTyped/DefinitelyTyped.git) - (Latest 0.17.6)
+- 🟧 [firebase@11.10.0](https://github.com/firebase/firebase-js-sdk.git) - (Latest 12.15.0) - Is behind 1 major version.
 - 🟧 [husky@8.0.3](https://github.com/typicode/husky.git) - (Latest 9.1.7) - Is behind 1 major version.
-- 🟥 [husky-init@8.0.0](https://github.com/typicode/husky-init.git) - Unmaintained (3.8 years since last release)
-- 🟧 [jasmine-core@4.6.0](https://github.com/jasmine/jasmine.git) - (Latest 5.13.0) - Is behind 1 major version.
-- 🟥 [jasmine-spec-reporter@7.0.0](https://github.com/bcaudan/jasmine-spec-reporter.git) - Unmaintained (4.8 years since last release)
-- 🟧 [karma@6.4.4](https://github.com/karma-runner/karma.git) - May be unmaintained (1.5 years since last release)
-- 🟥 [karma-chrome-launcher@3.2.0](https://github.com/karma-runner/karma-chrome-launcher.git) - Unmaintained (2.8 years since last release)
-- 🟥 [karma-coverage@2.2.1](https://github.com/karma-runner/karma-coverage.git) - Unmaintained (2.6 years since last release)
-- 🟥 [karma-coverage-istanbul-reporter@3.0.3](https://github.com/mattlewis92/karma-coverage-istanbul-reporter.git) - Unmaintained (5.7 years since last release)
+- 🟥 [husky-init@8.0.0](https://github.com/typicode/husky-init.git) - Unmaintained (4.1 years since last release)
+- 🟧 [jasmine-core@4.6.0](https://github.com/jasmine/jasmine.git) - (Latest 6.3.0) - Is behind 2 major versions.
+- 🟥 [jasmine-spec-reporter@7.0.0](https://github.com/bcaudan/jasmine-spec-reporter.git) - Unmaintained (5.2 years since last release)
+- 🟧 [karma@6.4.4](https://github.com/karma-runner/karma.git) - May be unmaintained (1.9 years since last release)
+- 🟥 [karma-chrome-launcher@3.2.0](https://github.com/karma-runner/karma-chrome-launcher.git) - Unmaintained (3.2 years since last release)
+- 🟥 [karma-coverage@2.2.1](https://github.com/karma-runner/karma-coverage.git) - Unmaintained (3 years since last release)
+- 🟥 [karma-coverage-istanbul-reporter@3.0.3](https://github.com/mattlewis92/karma-coverage-istanbul-reporter.git) - Unmaintained (6.1 years since last release)
 - 🟧 [karma-jasmine@4.0.2](https://github.com/karma-runner/karma-jasmine.git) - (Latest 5.1.0) - Is behind 1 major version.
-- 🟧 [karma-jasmine-html-reporter@1.7.0](https://github.com/dfederm/karma-jasmine-html-reporter.git) - (Latest 2.1.0) - Is behind 1 major version.
-- 🟩 [lottie-web@5.13.0](https://github.com/airbnb/lottie-web.git)
-- 🟩 [prettier@3.6.2](https://github.com/prettier/prettier.git) - (Latest 3.7.4)
-- 🟩 [pretty-quick@4.2.2](https://github.com/prettier/pretty-quick.git)
-- 🟩 [rxjs@7.8.2](https://github.com/reactivex/rxjs.git)
-- 🟥 [save-svg-as-png@1.4.17](https://github.com/exupero/saveSvgAsPng.git) - Unmaintained (6 years since last release)
-- 🟧 [swiper@11.2.10](https://github.com/nolimits4web/Swiper.git) - (Latest 12.0.3) - Is behind 1 major version.
-- 🟩 [swissqrbill@4.2.1](https://github.com/schoero/swissqrbill.git)
-- 🟩 [typescript@5.9.3](https://github.com/microsoft/TypeScript.git)
+- 🟧 [karma-jasmine-html-reporter@1.7.0](https://github.com/dfederm/karma-jasmine-html-reporter.git) - (Latest 2.2.0) - Is behind 1 major version.
+- 🟥 [karma-junit-reporter@2.0.1](https://github.com/karma-runner/karma-junit-reporter.git) - Unmaintained (6.7 years since last release)
+- 🟧 [lottie-web@5.13.0](https://github.com/airbnb/lottie-web.git) - May be unmaintained (1.1 years since last release)
+- 🟩 [maplibre-gl@5.24.0](https://github.com/maplibre/maplibre-gl-js.git)
+- 🟩 [prettier@3.8.4](https://github.com/prettier/prettier.git)
+- 🟧 [pretty-quick@4.2.2](https://github.com/prettier/pretty-quick.git) - May be unmaintained (1.1 years since last release)
+- 🟧 [rxjs@7.8.2](https://github.com/reactivex/rxjs.git) - May be unmaintained (1.3 years since last release)
+- 🟥 [save-svg-as-png@1.4.17](https://github.com/exupero/saveSvgAsPng.git) - Unmaintained (6.4 years since last release)
+- 🟩 [swiper@12.2.0](https://github.com/nolimits4web/Swiper.git)
+- 🟩 [swissqrbill@4.3.0](https://github.com/schoero/swissqrbill.git)
+- 🟧 [typescript@5.9.3](https://github.com/microsoft/TypeScript.git) - (Latest 6.0.3) - Is behind 1 major version.
 - 🟧 [web-social-share@9.1.0](https://github.com/peterpeterparker/web-social-share.git) - (Latest 10.0.0) - Is behind 1 major version.
-- 🟥 [xlsx@0.18.5](https://github.com/SheetJS/sheetjs.git) - Unmaintained (3.9 years since last release)
-- 🟩 [zone.js@0.15.1](https://github.com/angular/angular.git) - (Latest 0.16.0)
+- 🟥 [xlsx@0.18.5](https://github.com/SheetJS/sheetjs.git) - Unmaintained (4.2 years since last release)
+- 🟩 [zone.js@0.16.1](https://github.com/angular/angular.git) - (Latest 0.16.2)
 
 ### Maintenance Score
 
-32 out of 82 dependencies were up to date without issues.
+46 out of 82 dependencies were up to date without issues.
 
 ## Nonstandard naming
 

--- a/src/app/pages/championship/championship-detail/championship-detail.page.ts
+++ b/src/app/pages/championship/championship-detail/championship-detail.page.ts
@@ -5,6 +5,7 @@ import {
   ModalController,
 } from "@ionic/angular";
 import { Game } from "src/app/models/game";
+import { Capacitor } from "@capacitor/core";
 import { ChampionshipService } from "src/app/services/firebase/championship.service";
 import { forkJoin, lastValueFrom, Observable, of } from "rxjs";
 import { AuthService } from "src/app/services/auth.service";
@@ -18,11 +19,7 @@ import { MemberPage } from "../../member/member.page";
 import { FirebaseService } from "src/app/services/firebase.service";
 import { Team } from "src/app/models/team";
 import { UiService } from "src/app/services/ui.service";
-import {
-  MapService,
-  SWISSTOPO_STYLE,
-  MAP_MARKER_COLOR,
-} from "src/app/services/map.service";
+import { MapService, SWISSTOPO_STYLE } from "src/app/services/map.service";
 
 @Component({
   selector: "app-championship-detail",
@@ -37,8 +34,15 @@ export class ChampionshipDetailPage implements OnInit {
   game: Game;
 
   readonly mapStyle = SWISSTOPO_STYLE;
-  markerColor = MAP_MARKER_COLOR;
   ownPosition: [number, number] | null = null;
+
+  /**
+   * Liest die Marker-Farbe live aus dem aktiven Theme. Als Getter bleibt die
+   * Bindung reaktiv, falls zur Laufzeit zwischen Light/Dark gewechselt wird.
+   */
+  get markerColor(): string {
+    return this.mapService.getPrimaryColor();
+  }
 
   allowEdit: boolean = false;
 
@@ -76,7 +80,6 @@ export class ChampionshipDetailPage implements OnInit {
       return;
     }
 
-    this.markerColor = this.mapService.getPrimaryColor();
     await this.loadData();
     this.loadCurrentPosition();
   }
@@ -108,11 +111,13 @@ export class ChampionshipDetailPage implements OnInit {
 
   private async loadCurrentPosition() {
     // checkGeolocationPermission() triggert auf Native den Berechtigungs-Dialog,
-    // bevor die Position abgefragt wird. Das Resultat blockiert den Abruf bewusst
-    // nicht (auf Web liefert die Prüfung immer false, getCurrentPosition
-    // funktioniert dort dennoch via Browser-API).
-    await this.mapService.checkGeolocationPermission();
-    this.ownPosition = await this.mapService.getCurrentPosition();
+    // bevor die Position abgefragt wird. Wird sie dort nicht erteilt, sparen wir
+    // uns den ohnehin fehlschlagenden Positionsabruf. Auf Web liefert die Prüfung
+    // immer false, getCurrentPosition funktioniert dort dennoch via Browser-API.
+    const hasPermission = await this.mapService.checkGeolocationPermission();
+    if (hasPermission || !Capacitor.isNativePlatform()) {
+      this.ownPosition = await this.mapService.getCurrentPosition();
+    }
   }
 
   isTeamAdmin(teamAdminList: any[], teamId: string): boolean {

--- a/src/app/pages/championship/club-game-preview/club-game-preview.page.html
+++ b/src/app/pages/championship/club-game-preview/club-game-preview.page.html
@@ -1,5 +1,3 @@
-@if (game$ | async; as game) {
-
 <ion-header [translucent]="true">
   <ion-toolbar>
     <ion-buttons slot="secondary">
@@ -9,6 +7,8 @@
     <ion-title>{{"common.details" | translate}}</ion-title>
   </ion-toolbar>
 </ion-header>
+
+@if (game$ | async; as game) {
 
 <ion-content>
   <ion-header collapse="condense">
@@ -144,16 +144,6 @@
   </ion-text>
 </ion-content>
 } @else {
-
-<ion-header [translucent]="true">
-  <ion-toolbar>
-    <ion-buttons slot="secondary">
-      <ion-button (click)="close()">{{"common.close" | translate}}</ion-button>
-    </ion-buttons>
-
-    <ion-title>{{"common.details" | translate}}</ion-title>
-  </ion-toolbar>
-</ion-header>
 
 <ion-content>
   <ion-header collapse="condense">

--- a/src/app/pages/championship/club-game-preview/club-game-preview.page.ts
+++ b/src/app/pages/championship/club-game-preview/club-game-preview.page.ts
@@ -2,16 +2,13 @@ import { Component, Input, OnInit } from "@angular/core";
 import { ModalController } from "@ionic/angular";
 import { Game } from "src/app/models/game";
 import { Browser } from "@capacitor/browser";
+import { Capacitor } from "@capacitor/core";
 import { ChampionshipService } from "src/app/services/firebase/championship.service";
 import { Observable, of } from "rxjs";
 import { catchError, map, switchMap } from "rxjs/operators";
 import { FirebaseService } from "src/app/services/firebase.service";
 import { UiService } from "src/app/services/ui.service";
-import {
-  MapService,
-  SWISSTOPO_STYLE,
-  MAP_MARKER_COLOR,
-} from "src/app/services/map.service";
+import { MapService, SWISSTOPO_STYLE } from "src/app/services/map.service";
 
 @Component({
   selector: "app-club-game-preview",
@@ -26,8 +23,15 @@ export class ClubGamePreviewPage implements OnInit {
   game: Game;
 
   readonly mapStyle = SWISSTOPO_STYLE;
-  markerColor = MAP_MARKER_COLOR;
   ownPosition: [number, number] | null = null;
+
+  /**
+   * Liest die Marker-Farbe live aus dem aktiven Theme. Als Getter bleibt die
+   * Bindung reaktiv, falls zur Laufzeit zwischen Light/Dark gewechselt wird.
+   */
+  get markerColor(): string {
+    return this.mapService.getPrimaryColor();
+  }
 
   game$: Observable<Game>;
 
@@ -47,18 +51,19 @@ export class ClubGamePreviewPage implements OnInit {
       return;
     }
 
-    this.markerColor = this.mapService.getPrimaryColor();
     this.game$ = this.getGame(this.game.teamId, this.game.id);
     this.loadCurrentPosition();
   }
 
   private async loadCurrentPosition() {
     // checkGeolocationPermission() triggert auf Native den Berechtigungs-Dialog,
-    // bevor die Position abgefragt wird. Das Resultat blockiert den Abruf bewusst
-    // nicht (auf Web liefert die Prüfung immer false, getCurrentPosition
-    // funktioniert dort dennoch via Browser-API).
-    await this.mapService.checkGeolocationPermission();
-    this.ownPosition = await this.mapService.getCurrentPosition();
+    // bevor die Position abgefragt wird. Wird sie dort nicht erteilt, sparen wir
+    // uns den ohnehin fehlschlagenden Positionsabruf. Auf Web liefert die Prüfung
+    // immer false, getCurrentPosition funktioniert dort dennoch via Browser-API.
+    const hasPermission = await this.mapService.checkGeolocationPermission();
+    if (hasPermission || !Capacitor.isNativePlatform()) {
+      this.ownPosition = await this.mapService.getCurrentPosition();
+    }
   }
 
   // Simplified getGame - only fetches general game data, no members/participants

--- a/src/app/pages/helfer/helfer-add/helfer-add.page.ts
+++ b/src/app/pages/helfer/helfer-add/helfer-add.page.ts
@@ -11,9 +11,11 @@ import {
   Observable,
   Subscription,
   catchError,
+  lastValueFrom,
   map,
   take,
 } from "rxjs";
+import { TranslateService } from "@ngx-translate/core";
 import { Club } from "src/app/models/club";
 import { HelferEvent, Schicht } from "src/app/models/event";
 import { Game } from "src/app/models/game";
@@ -54,6 +56,7 @@ export class HelferAddPage implements OnInit {
 
     private championshipService: ChampionshipService,
     private uiService: UiService,
+    private translate: TranslateService,
   ) {
     this.event = {
       id: "",
@@ -404,10 +407,15 @@ export class HelferAddPage implements OnInit {
       return null;
     }
 
-    // Bestätigungsdialog anzeigen
+    // Bestätigungsdialog anzeigen, inkl. Hinweis dass Datum/Uhrzeit
+    // nachträglich nicht mehr geändert werden können
     const confirmed = await this.uiService.showConfirmDialog({
-      header: "Event erstellen",
-      message: "Möchten Sie dieses Event wirklich erstellen?",
+      header: await lastValueFrom(
+        this.translate.get("helfer-add.confirm_create_header"),
+      ),
+      message: await lastValueFrom(
+        this.translate.get("helfer-add.confirm_create_message"),
+      ),
     });
 
     if (confirmed) {

--- a/src/app/pages/news/news/news.page.ts
+++ b/src/app/pages/news/news/news.page.ts
@@ -88,10 +88,10 @@ export class NewsPage implements OnInit {
   gamePreviewDays: number = 10;
   hasChampionshipModule: boolean = false;
 
-  currentSegment: "all" | "verein" | "verband" = "all";
-  private segmentFilter$ = new BehaviorSubject<"all" | "verein" | "verband">(
-    "all",
-  );
+  // Filter value: "all", "verband" or a specific club id. A club id filters
+  // the list down to that single club's news (source === "verein").
+  currentSegment: string = "all";
+  private segmentFilter$ = new BehaviorSubject<string>("all");
 
   constructor(
     private readonly notificationService: NotificationService,
@@ -202,7 +202,11 @@ export class NewsPage implements OnInit {
     ]).pipe(
       map(([list, filter]) => {
         if (filter === "all") return list;
-        return list.filter((n) => n.source === filter);
+        if (filter === "verband") {
+          return list.filter((n) => n.source === "verband");
+        }
+        // Any other value is a club id: show only that club's news.
+        return list.filter((n) => n.source === "verein" && n.clubId === filter);
       }),
     );
     this.notifications$ = this.getNotifications().pipe(
@@ -237,7 +241,9 @@ export class NewsPage implements OnInit {
     try {
       const { value } = await Preferences.get({ key: "newsFilter" });
       if (value) {
-        const savedFilter = value as "all" | "verein" | "verband";
+        // The legacy generic "verein" value no longer maps to anything (it has
+        // been replaced by per-club filters) — fall back to "all" in that case.
+        const savedFilter = value === "verein" ? "all" : value;
         this.currentSegment = savedFilter;
         this.segmentFilter$.next(savedFilter);
         this.filterValue = savedFilter === "all" ? "" : savedFilter;
@@ -250,7 +256,7 @@ export class NewsPage implements OnInit {
   /**
    * Speichert die aktuelle Filter-Einstellung im lokalen Storage
    */
-  async saveFilter(filter: "all" | "verein" | "verband"): Promise<void> {
+  async saveFilter(filter: string): Promise<void> {
     try {
       await Preferences.set({
         key: "newsFilter",
@@ -356,6 +362,9 @@ export class NewsPage implements OnInit {
                     map((arr) =>
                       arr.map((n) => ({
                         ...n,
+                        // Ensure the club id is set so the per-club filter works
+                        // even if the document itself doesn't carry it.
+                        clubId: club.id,
                         source: "verein" as const,
                       })),
                     ),
@@ -672,31 +681,40 @@ export class NewsPage implements OnInit {
   }
 
   async openFilter() {
+    // Load the user's clubs so each can be offered as its own filter option.
+    const clubs =
+      (await this.clubList$
+        ?.pipe(take(1))
+        .toPromise()
+        .catch(() => [])) ?? [];
+
+    const inputs: any[] = [
+      {
+        name: "all",
+        type: "radio",
+        label: "Alle",
+        value: "all",
+        checked: this.currentSegment === "all",
+      },
+      {
+        name: "verband",
+        type: "radio",
+        label: "Verband",
+        value: "verband",
+        checked: this.currentSegment === "verband",
+      },
+      ...clubs.map((club) => ({
+        name: club.id,
+        type: "radio",
+        label: club.name,
+        value: club.id,
+        checked: this.currentSegment === club.id,
+      })),
+    ];
+
     const alert = await this.alertCtrl.create({
       header: "News filtern",
-      inputs: [
-        {
-          name: "all",
-          type: "radio",
-          label: "Alle",
-          value: "all",
-          checked: this.currentSegment === "all",
-        },
-        {
-          name: "verband",
-          type: "radio",
-          label: "Verband",
-          value: "verband",
-          checked: this.currentSegment === "verband",
-        },
-        {
-          name: "verein",
-          type: "radio",
-          label: "Verein",
-          value: "verein",
-          checked: this.currentSegment === "verein",
-        },
-      ],
+      inputs,
       buttons: [
         {
           text: this.translate.instant("common.cancel") || "Abbrechen",
@@ -713,7 +731,7 @@ export class NewsPage implements OnInit {
     const { data, role } = await alert.onWillDismiss();
     if (role === "confirm") {
       const selected = (data as any)?.values ?? (data as any);
-      const value = (selected as "all" | "verein" | "verband") || "all";
+      const value = (selected as string) || "all";
       this.currentSegment = value;
       this.segmentFilter$.next(value);
       this.filterValue = value === "all" ? "" : value;
@@ -726,10 +744,7 @@ export class NewsPage implements OnInit {
   async onSegmentChanged(event: CustomEvent<{ value?: string | number }>) {
     const raw = event.detail?.value;
     const value =
-      ((typeof raw === "number" ? String(raw) : raw) as
-        | "all"
-        | "verein"
-        | "verband") || "all";
+      (typeof raw === "number" ? String(raw) : (raw as string)) || "all";
     this.currentSegment = value;
     this.segmentFilter$.next(value);
 

--- a/src/app/services/map.service.ts
+++ b/src/app/services/map.service.ts
@@ -106,8 +106,10 @@ export class MapService {
   }
 
   /**
-   * Öffnet die Adresse in der nativen Karten-/Navigations-App.
-   * Plattform-spezifisch: iOS maps:, Android geo:, Web Google Maps.
+   * Startet die Navigation zur Adresse in der nativen Karten-/Navigations-App.
+   * Es wird eine Route (aktueller Standort -> Ziel) geöffnet, kein reiner
+   * Karten-Suchtreffer. Plattform-spezifisch: iOS maps:, Android
+   * google.navigation:, Web Google Maps Directions.
    */
   async openMapsNavigation(location: MapLocation): Promise<void> {
     const query =
@@ -118,15 +120,21 @@ export class MapService {
     const platform = Capacitor.getPlatform();
 
     if (platform === "ios") {
-      window.open(`maps:?q=${encoded}`, "_system");
+      // daddr = destination address -> Apple Maps öffnet die Routenplanung
+      window.open(`maps:?daddr=${encoded}`, "_system");
       return;
     }
 
     if (platform === "android") {
-      window.open(`geo:0,0?q=${encoded}`, "_system");
+      // google.navigation:q startet die Turn-by-Turn-Navigation
+      window.open(`google.navigation:q=${encoded}`, "_system");
       return;
     }
 
-    window.open(`https://maps.google.com/?q=${encoded}`, "_system");
+    // Web: Google Maps Directions API (Route vom aktuellen Standort zum Ziel)
+    window.open(
+      `https://www.google.com/maps/dir/?api=1&destination=${encoded}`,
+      "_system",
+    );
   }
 }

--- a/src/assets/lang/de.json
+++ b/src/assets/lang/de.json
@@ -420,7 +420,9 @@
     "schichten": "Helferschichten"
   },
   "helfer-add": {
-    "new__helper_event": "Neuer Helferevent"
+    "new__helper_event": "Neuer Helferevent",
+    "confirm_create_header": "Helferevent erstellen",
+    "confirm_create_message": "Möchten Sie diesen Helferevent wirklich erstellen? Hinweis: Datum und Uhrzeit können nachträglich nicht mehr geändert werden."
   },
   "helfer-detail": {
     "helfer_innen_for": "Helfer für",

--- a/src/assets/lang/en.json
+++ b/src/assets/lang/en.json
@@ -402,7 +402,9 @@
     "schichten": "Helper shifts"
   },
   "helfer-add": {
-    "new__helper_event": "New helper event"
+    "new__helper_event": "New helper event",
+    "confirm_create_header": "Create helper event",
+    "confirm_create_message": "Do you really want to create this helper event? Note: the date and time cannot be changed afterwards."
   },
   "helfer-detail": {
     "helfer_innen_for": "Helpers for",

--- a/src/assets/lang/fr.json
+++ b/src/assets/lang/fr.json
@@ -401,7 +401,9 @@
     "schichten": "Créneaux de bénévolat"
   },
   "helfer-add": {
-    "new__helper_event": "Nouvel événement de bénévole"
+    "new__helper_event": "Nouvel événement de bénévole",
+    "confirm_create_header": "Créer un événement de bénévole",
+    "confirm_create_message": "Voulez-vous vraiment créer cet événement de bénévole ? Remarque : la date et l'heure ne pourront plus être modifiées par la suite."
   },
   "helfer-detail": {
     "helfer_innen_for": "Bénévoles pour",

--- a/src/assets/lang/it.json
+++ b/src/assets/lang/it.json
@@ -401,7 +401,9 @@
     "schichten": "Turni di volontariato"
   },
   "helfer-add": {
-    "new__helper_event": "Nuovo evento di volontariato"
+    "new__helper_event": "Nuovo evento di volontariato",
+    "confirm_create_header": "Crea evento di volontariato",
+    "confirm_create_message": "Vuoi davvero creare questo evento di volontariato? Nota: la data e l'ora non potranno più essere modificate in seguito."
   },
   "helfer-detail": {
     "helfer_innen_for": "Volontari per",


### PR DESCRIPTION
## Beschreibung

Behebt #198 — der News-Filter bietet neu jeden Verein, in dem der User (bzw. dessen Kinder) Mitglied ist, als eigene Filteroption an, statt einer generischen "Verein"-Auswahl.

**Vorher:** Alle · Verband · Verein
**Neu:** Alle · Verband · [Verein 1] · [Verein 2] · …

## Änderungen

- `openFilter()` baut die Radio-Optionen dynamisch aus `clubList$` auf (Alle, Verband, dann ein Eintrag pro Verein mit Vereinsname).
- Die Filterlogik in `loadData()` unterscheidet jetzt `"all"`, `"verband"` und beliebige Club-IDs (`source === "verein" && clubId === filter`).
- Club-News tragen beim Mappen explizit ihre `clubId`, damit das Filtern pro Verein zuverlässig funktioniert, auch wenn das Dokument selbst keine `clubId` enthält.
- Filterwerte sind nun beliebige Strings (Club-ID). Der alte generische `"verein"`-Wert (aus den Preferences älterer App-Versionen) fällt beim Laden auf `"all"` zurück.

## Test

- `tsc --noEmit -p tsconfig.app.json` läuft fehlerfrei durch.

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)
