### PR TITLE
fix(helfer): Schichten-Liste im Helfer-Detail zuverlässig laden

### DIFF
--- a/src/app/pages/helfer/helfer-detail/helfer-detail.page.spec.ts
+++ b/src/app/pages/helfer/helfer-detail/helfer-detail.page.spec.ts
@@ -6,7 +6,7 @@ import {
   ToastController,
 } from "@ionic/angular";
 import { TranslateModule } from "@ngx-translate/core";
-import { of } from "rxjs";
+import { NEVER, of, take, throwError } from "rxjs";
 import { Timestamp } from "@angular/fire/firestore";
 
 import { HelferDetailPage } from "./helfer-detail.page";
@@ -64,8 +64,12 @@ describe("HelferDetailPage", () => {
   };
 
   beforeEach(waitForAsync(() => {
-    authServiceSpy = jasmine.createSpyObj("AuthService", ["getUser$"]);
+    authServiceSpy = jasmine.createSpyObj("AuthService", [
+      "getUser$",
+      "getAuthenticatedUser$",
+    ]);
     authServiceSpy.getUser$.and.returnValue(of(mockUser as any));
+    authServiceSpy.getAuthenticatedUser$.and.returnValue(of(mockUser as any));
 
     eventServiceSpy = jasmine.createSpyObj("EventService", [
       "getClubHelferEventRef",
@@ -555,6 +559,119 @@ describe("HelferDetailPage", () => {
       await component.ngOnInit();
       expect(component.event$).toBeDefined();
       expect(component.schichten$).toBeDefined();
+    });
+  });
+
+  describe("getHelferEventSchichtenWithAttendees - loading robustness", () => {
+    const rawSchicht = {
+      id: "schicht-1",
+      name: "Grillstand",
+      countNeeded: 3,
+      points: 2,
+      timeFrom: "10:00",
+      timeTo: "14:00",
+    };
+
+    beforeEach(() => {
+      component.user = mockUser as any;
+      component.children = [];
+    });
+
+    it("should emit even when the club member list is empty (forkJoin guard)", (done) => {
+      eventServiceSpy.getClubHelferEventSchichtenRef.and.returnValue(
+        of([{ ...rawSchicht }]),
+      );
+      eventServiceSpy.getClubHelferEventSchichtAttendeesRef.and.returnValue(
+        of([{ id: "member-1", status: true, changedAt: Timestamp.now() }]),
+      );
+      fbServiceSpy.getClubMemberRefs.and.returnValue(of([]));
+
+      component
+        .getHelferEventSchichtenWithAttendees("club-1", "helfer-1")
+        .pipe(take(1))
+        .subscribe((result) => {
+          // Before the fix, forkJoin([]) completed without emitting and the
+          // Schichten list stayed on its loading state forever.
+          expect(result.length).toBe(1);
+          expect(result[0].attendeeListTrue).toEqual([]);
+          expect(Array.isArray(result[0].status)).toBeTrue();
+          done();
+        });
+    });
+
+    it("should not error when an attendee document has no changedAt", (done) => {
+      eventServiceSpy.getClubHelferEventSchichtenRef.and.returnValue(
+        of([{ ...rawSchicht }]),
+      );
+      fbServiceSpy.getClubMemberRefs.and.returnValue(
+        of([{ id: "user-123" }] as any),
+      );
+      userProfileServiceSpy.getUserProfileById.and.returnValue(
+        of({ id: "user-123", firstName: "Katja", lastName: "F" } as any),
+      );
+      eventServiceSpy.getClubHelferEventSchichtAttendeesRef.and.returnValue(
+        of([{ id: "user-123", status: true }]), // legacy doc without changedAt
+      );
+
+      component
+        .getHelferEventSchichtenWithAttendees("club-1", "helfer-1")
+        .pipe(take(1))
+        .subscribe((result) => {
+          // Before the fix, changedAt.toDate() threw and the error fallback
+          // emitted status: null, which crashed the template.
+          expect(result[0].attendeeListTrue.length).toBe(1);
+          expect(Array.isArray(result[0].status)).toBeTrue();
+          expect(result[0].status[0].id).toBe("user-123");
+          done();
+        });
+    });
+
+    it("should emit a template-safe fallback when club members cannot be loaded", (done) => {
+      spyOn(console, "error");
+      eventServiceSpy.getClubHelferEventSchichtenRef.and.returnValue(
+        of([{ ...rawSchicht }]),
+      );
+      fbServiceSpy.getClubMemberRefs.and.returnValue(
+        throwError(() => new Error("permission-denied")),
+      );
+
+      component
+        .getHelferEventSchichtenWithAttendees("club-1", "helfer-1")
+        .pipe(take(1))
+        .subscribe((result) => {
+          expect(result.length).toBe(1);
+          expect(Array.isArray(result[0].status)).toBeTrue();
+          expect(result[0].children).toEqual([]);
+          expect(result[0].attendeeListTrue).toEqual([]);
+          done();
+        });
+    });
+
+    it("should render schichten immediately while profile reads are pending (eagerPlaceholder)", (done) => {
+      eventServiceSpy.getClubHelferEventSchichtenRef.and.returnValue(
+        of([{ ...rawSchicht }]),
+      );
+      fbServiceSpy.getClubMemberRefs.and.returnValue(
+        of([{ id: "member-1" }] as any),
+      );
+      // Profile read that never resolves — previously this hung the whole list.
+      userProfileServiceSpy.getUserProfileById.and.returnValue(NEVER as any);
+      eventServiceSpy.getClubHelferEventSchichtAttendeesRef.and.returnValue(
+        of([]),
+      );
+
+      component
+        .getHelferEventSchichtenWithAttendees("club-1", "helfer-1", {
+          eagerPlaceholder: true,
+        })
+        .pipe(take(1))
+        .subscribe((result) => {
+          expect(result.length).toBe(1);
+          expect(result[0].id).toBe("schicht-1");
+          expect(result[0].attendeeListTrue).toEqual([]);
+          expect(Array.isArray(result[0].status)).toBeTrue();
+          done();
+        });
     });
   });
 

--- a/src/app/pages/helfer/helfer-detail/helfer-detail.page.spec.ts
+++ b/src/app/pages/helfer/helfer-detail/helfer-detail.page.spec.ts
@@ -254,12 +254,19 @@ describe("HelferDetailPage", () => {
         placeholderSchicht,
       );
 
+      await component.addMembersToSchicht(
+        slidingItemMock as any,
+        placeholderSchicht,
+      );
+
       // While counts are unresolved, a tap must not bypass the capacity
-      // check and register an attendee.
+      // check, register an attendee, or offer "available" members based on
+      // an empty placeholder attendee list.
       expect(
         eventServiceSpy.setClubHelferEventSchichtAttendeeStatusAdmin,
       ).not.toHaveBeenCalled();
       expect(fbServiceSpy.getClubMemberRefs).not.toHaveBeenCalled();
+      expect(uiServiceSpy.showFormDialog).not.toHaveBeenCalled();
     });
 
     it("should block signup when shift is full (non-admin)", async () => {

--- a/src/app/pages/helfer/helfer-detail/helfer-detail.page.spec.ts
+++ b/src/app/pages/helfer/helfer-detail/helfer-detail.page.spec.ts
@@ -1,4 +1,10 @@
-import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
+import {
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  tick,
+  waitForAsync,
+} from "@angular/core/testing";
 import { CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
 import {
   AlertController,
@@ -6,7 +12,7 @@ import {
   ToastController,
 } from "@ionic/angular";
 import { TranslateModule } from "@ngx-translate/core";
-import { NEVER, of, take, throwError } from "rxjs";
+import { NEVER, delay, of, take, throwError } from "rxjs";
 import { Timestamp } from "@angular/fire/firestore";
 
 import { HelferDetailPage } from "./helfer-detail.page";
@@ -646,6 +652,40 @@ describe("HelferDetailPage", () => {
           done();
         });
     });
+
+    it("should degrade a slow profile read to the Unknown fallback via timeout", fakeAsync(() => {
+      spyOn(console, "error");
+      eventServiceSpy.getClubHelferEventSchichtenRef.and.returnValue(
+        of([{ ...rawSchicht }]),
+      );
+      fbServiceSpy.getClubMemberRefs.and.returnValue(
+        of([{ id: "member-1" }] as any),
+      );
+      // Profile read that only resolves after the 10s timeout budget.
+      userProfileServiceSpy.getUserProfileById.and.returnValue(
+        of({
+          id: "member-1",
+          firstName: "Slow",
+          lastName: "Reader",
+        } as any).pipe(delay(20000)),
+      );
+      eventServiceSpy.getClubHelferEventSchichtAttendeesRef.and.returnValue(
+        of([{ id: "member-1", status: true, changedAt: Timestamp.now() }]),
+      );
+
+      let result: any[] | undefined;
+      const subscription = component
+        .getHelferEventSchichtenWithAttendees("club-1", "helfer-1")
+        .subscribe((r) => (result = r));
+
+      expect(result).toBeUndefined(); // still waiting on the profile read
+      tick(10000); // timeout fires and substitutes the Unknown profile
+
+      expect(result).toBeDefined();
+      expect(result![0].attendeeListTrue.length).toBe(1);
+      expect(result![0].attendeeListTrue[0].firstName).toBe("Unknown");
+      subscription.unsubscribe();
+    }));
 
     it("should render schichten immediately while profile reads are pending (eagerPlaceholder)", (done) => {
       eventServiceSpy.getClubHelferEventSchichtenRef.and.returnValue(

--- a/src/app/pages/helfer/helfer-detail/helfer-detail.page.spec.ts
+++ b/src/app/pages/helfer/helfer-detail/helfer-detail.page.spec.ts
@@ -79,10 +79,8 @@ describe("HelferDetailPage", () => {
 
   beforeEach(waitForAsync(() => {
     authServiceSpy = jasmine.createSpyObj("AuthService", [
-      "getUser$",
       "getAuthenticatedUser$",
     ]);
-    authServiceSpy.getUser$.and.returnValue(of(mockUser as any));
     authServiceSpy.getAuthenticatedUser$.and.returnValue(of(mockUser as any));
 
     eventServiceSpy = jasmine.createSpyObj("EventService", [
@@ -225,6 +223,43 @@ describe("HelferDetailPage", () => {
         "schicht-1",
         "user-123",
       );
+    });
+
+    it("should ignore taps while the shift row is still a placeholder", async () => {
+      component.event = mockHelferEvent as HelferEvent;
+      component.clubAdminList$ = of([]);
+
+      const placeholderSchicht = {
+        ...mockSchicht,
+        attendeeListTrue: [],
+        pending: true,
+      };
+      const eventData = {
+        ...mockHelferEvent,
+        date: Timestamp.fromDate(futureDate),
+        timeFrom: "10:00",
+      };
+
+      await component.toggleSchichtItem(
+        slidingItemMock as any,
+        true,
+        eventData,
+        placeholderSchicht,
+        "user-123",
+      );
+      await component.toggleSchicht(
+        slidingItemMock as any,
+        true,
+        eventData,
+        placeholderSchicht,
+      );
+
+      // While counts are unresolved, a tap must not bypass the capacity
+      // check and register an attendee.
+      expect(
+        eventServiceSpy.setClubHelferEventSchichtAttendeeStatusAdmin,
+      ).not.toHaveBeenCalled();
+      expect(fbServiceSpy.getClubMemberRefs).not.toHaveBeenCalled();
     });
 
     it("should block signup when shift is full (non-admin)", async () => {

--- a/src/app/pages/helfer/helfer-detail/helfer-detail.page.spec.ts
+++ b/src/app/pages/helfer/helfer-detail/helfer-detail.page.spec.ts
@@ -16,6 +16,7 @@ import {
   BehaviorSubject,
   NEVER,
   Subject,
+  defer,
   delay,
   of,
   take,
@@ -863,6 +864,61 @@ describe("HelferDetailPage", () => {
           expect(Array.isArray(result[0].status)).toBeTrue();
           done();
         });
+    });
+  });
+
+  describe("schichten$ stream lifetime", () => {
+    it("should not restart the read cascade on re-subscription or view re-entry", async () => {
+      let memberListSubscriptions = 0;
+      eventServiceSpy.getClubHelferEventSchichtenRef.and.returnValue(
+        of([
+          {
+            id: "schicht-1",
+            name: "Grillstand",
+            countNeeded: 3,
+            points: 2,
+            timeFrom: "10:00",
+            timeTo: "14:00",
+          },
+        ]),
+      );
+      fbServiceSpy.getClubMemberRefs.and.returnValue(
+        defer(() => {
+          memberListSubscriptions++;
+          return of([{ id: "user-123" }] as any);
+        }),
+      );
+      userProfileServiceSpy.getUserProfileById.and.returnValue(
+        of({ id: "user-123", firstName: "Katja", lastName: "F" } as any),
+      );
+      eventServiceSpy.getClubHelferEventSchichtAttendeesRef.and.returnValue(
+        of([]),
+      );
+
+      // The TestBed setup can already have run ngOnInit (initial change
+      // detection) with the default stubs; reset the built streams so
+      // loadData rebuilds them with the stubs configured above.
+      (component as any).schichtenSub?.unsubscribe();
+      (component as any).event$ = undefined;
+      (component as any).schichten$ = undefined;
+
+      await component.ngOnInit();
+      expect(memberListSubscriptions).toBe(1);
+
+      // ionViewWillEnter must not rebuild the streams (second cascade).
+      component.ionViewWillEnter();
+      expect(memberListSubscriptions).toBe(1);
+
+      // Async pipes churn on @if toggles (member view <-> admin-edit view):
+      // unsubscribe/resubscribe must reuse the pinned shared subscription
+      // instead of restarting the member/profile read cascade.
+      component.schichten$.pipe(take(1)).subscribe().unsubscribe();
+      component.schichten$.pipe(take(1)).subscribe().unsubscribe();
+      expect(memberListSubscriptions).toBe(1);
+
+      // ngOnDestroy releases the pinned subscription with the modal.
+      component.ngOnDestroy();
+      expect((component as any).schichtenSub.closed).toBeTrue();
     });
   });
 

--- a/src/app/pages/helfer/helfer-detail/helfer-detail.page.spec.ts
+++ b/src/app/pages/helfer/helfer-detail/helfer-detail.page.spec.ts
@@ -709,6 +709,37 @@ describe("HelferDetailPage", () => {
       subscription.unsubscribe();
     });
 
+    it("should show the placeholder first when the member list itself is slow", fakeAsync(() => {
+      eventServiceSpy.getClubHelferEventSchichtenRef.and.returnValue(
+        of([{ ...rawSchicht }]),
+      );
+      fbServiceSpy.getClubMemberRefs.and.returnValue(
+        of([{ id: "user-123" }] as any).pipe(delay(1000)),
+      );
+      userProfileServiceSpy.getUserProfileById.and.returnValue(
+        of({ id: "user-123", firstName: "Katja", lastName: "F" } as any),
+      );
+      eventServiceSpy.getClubHelferEventSchichtAttendeesRef.and.returnValue(
+        of([{ id: "user-123", status: true, changedAt: Timestamp.now() }]),
+      );
+
+      const emissions: any[][] = [];
+      const subscription = component
+        .getHelferEventSchichtenWithAttendees("club-1", "helfer-1", {
+          eagerPlaceholder: true,
+        })
+        .subscribe((r) => emissions.push(r));
+
+      // Placeholder renders immediately, before the member list resolves.
+      expect(emissions.length).toBe(1);
+      expect(emissions[0][0].attendeeListTrue).toEqual([]);
+
+      tick(1000);
+      expect(emissions.length).toBe(2);
+      expect(emissions[1][0].attendeeListTrue.length).toBe(1);
+      subscription.unsubscribe();
+    }));
+
     it("should degrade a slow profile read to the Unknown fallback via timeout", fakeAsync(() => {
       spyOn(console, "error");
       eventServiceSpy.getClubHelferEventSchichtenRef.and.returnValue(

--- a/src/app/pages/helfer/helfer-detail/helfer-detail.page.spec.ts
+++ b/src/app/pages/helfer/helfer-detail/helfer-detail.page.spec.ts
@@ -694,11 +694,33 @@ describe("HelferDetailPage", () => {
       component
         .getHelferEventSchichtenWithAttendees("club-1", "helfer-1")
         .pipe(take(1))
-        .subscribe((result) => {
+        .subscribe(async (result) => {
           expect(result.length).toBe(1);
           expect(Array.isArray(result[0].status)).toBeTrue();
           expect(result[0].children).toEqual([]);
           expect(result[0].attendeeListTrue).toEqual([]);
+          // Error fallbacks are pending too: with no resolved attendee data
+          // the capacity check would see 0, so taps must be ignored.
+          expect(result[0].pending).toBeTrue();
+
+          const slidingItemMock = {
+            closeOpened: jasmine.createSpy("closeOpened").and.resolveTo(),
+          };
+          fbServiceSpy.getClubMemberRefs.calls.reset();
+          await component.toggleSchicht(
+            slidingItemMock as any,
+            true,
+            mockHelferEvent,
+            result[0],
+          );
+          await component.addMembersToSchicht(
+            slidingItemMock as any,
+            result[0],
+          );
+          expect(fbServiceSpy.getClubMemberRefs).not.toHaveBeenCalled();
+          expect(
+            eventServiceSpy.setClubHelferEventSchichtAttendeeStatusAdmin,
+          ).not.toHaveBeenCalled();
           done();
         });
     });

--- a/src/app/pages/helfer/helfer-detail/helfer-detail.page.spec.ts
+++ b/src/app/pages/helfer/helfer-detail/helfer-detail.page.spec.ts
@@ -12,7 +12,15 @@ import {
   ToastController,
 } from "@ionic/angular";
 import { TranslateModule } from "@ngx-translate/core";
-import { NEVER, delay, of, take, throwError } from "rxjs";
+import {
+  BehaviorSubject,
+  NEVER,
+  Subject,
+  delay,
+  of,
+  take,
+  throwError,
+} from "rxjs";
 import { Timestamp } from "@angular/fire/firestore";
 
 import { HelferDetailPage } from "./helfer-detail.page";
@@ -651,6 +659,54 @@ describe("HelferDetailPage", () => {
           expect(result[0].attendeeListTrue).toEqual([]);
           done();
         });
+    });
+
+    it("should not replay the eager placeholder on live schichten/attendees updates", () => {
+      const schichtenSubject = new Subject<any[]>();
+      const attendeesSubject = new BehaviorSubject<any[]>([
+        { id: "user-123", status: true, changedAt: Timestamp.now() },
+      ]);
+      eventServiceSpy.getClubHelferEventSchichtenRef.and.returnValue(
+        schichtenSubject,
+      );
+      fbServiceSpy.getClubMemberRefs.and.returnValue(
+        of([{ id: "user-123" }] as any),
+      );
+      userProfileServiceSpy.getUserProfileById.and.returnValue(
+        of({ id: "user-123", firstName: "Katja", lastName: "F" } as any),
+      );
+      eventServiceSpy.getClubHelferEventSchichtAttendeesRef.and.returnValue(
+        attendeesSubject,
+      );
+
+      const emissions: any[][] = [];
+      const subscription = component
+        .getHelferEventSchichtenWithAttendees("club-1", "helfer-1", {
+          eagerPlaceholder: true,
+        })
+        .subscribe((r) => emissions.push(r));
+
+      // Initial load: placeholder first, then the resolved join.
+      schichtenSubject.next([{ ...rawSchicht }]);
+      expect(emissions.length).toBe(2);
+      expect(emissions[0][0].attendeeListTrue).toEqual([]);
+      expect(emissions[1][0].attendeeListTrue.length).toBe(1);
+
+      // Live attendee update: resolved data only, no placeholder flash.
+      attendeesSubject.next([
+        { id: "user-123", status: false, changedAt: Timestamp.now() },
+      ]);
+      expect(emissions.length).toBe(3);
+      expect(emissions[2][0].attendeeListFalse.length).toBe(1);
+
+      // Live schichten-collection update (e.g. admin renames a Schicht):
+      // no placeholder flash either — viewers keep resolved data.
+      schichtenSubject.next([{ ...rawSchicht, name: "Grillstand neu" }]);
+      expect(emissions.length).toBe(4);
+      expect(emissions[3][0].name).toBe("Grillstand neu");
+      expect(emissions[3][0].attendeeListFalse.length).toBe(1);
+
+      subscription.unsubscribe();
     });
 
     it("should degrade a slow profile read to the Unknown fallback via timeout", fakeAsync(() => {

--- a/src/app/pages/helfer/helfer-detail/helfer-detail.page.ts
+++ b/src/app/pages/helfer/helfer-detail/helfer-detail.page.ts
@@ -169,6 +169,23 @@ export class HelferDetailPage implements OnInit {
     );
   }
 
+  /**
+   * Template-safe empty representation of a Schicht: the template reads
+   * status.length, children and the attendee lists unconditionally, so every
+   * emission (eager placeholder or error fallback) must carry this shape.
+   */
+  private toPlaceholderSchicht(schicht: any, unrespondedMembers: any[] = []) {
+    return {
+      ...schicht,
+      attendees: [],
+      attendeeListTrue: [],
+      attendeeListFalse: [],
+      unrespondedMembers,
+      status: [],
+      children: [],
+    };
+  }
+
   getHelferEventSchichtenWithAttendees(
     clubId: string,
     eventId: string,
@@ -318,18 +335,12 @@ export class HelferDetailPage implements OnInit {
                                 "Error fetching attendees for schicht:",
                                 err,
                               );
-                              // The template reads status.length and children,
-                              // so the fallback must keep the same shape as a
-                              // successful emission (status: null crashed it).
-                              return of({
-                                ...schicht,
-                                attendees: [],
-                                attendeeListTrue: [],
-                                attendeeListFalse: [],
-                                unrespondedMembers: clubMembersWithDetails,
-                                status: [],
-                                children: [],
-                              });
+                              return of(
+                                this.toPlaceholderSchicht(
+                                  schicht,
+                                  clubMembersWithDetails,
+                                ),
+                              );
                             }),
                           ),
                     );
@@ -340,15 +351,9 @@ export class HelferDetailPage implements OnInit {
               catchError((err) => {
                 console.error("Error fetching club members:", err);
                 return of(
-                  sortedSchichten.map((schicht) => ({
-                    ...schicht,
-                    attendees: [],
-                    attendeeListTrue: [],
-                    attendeeListFalse: [],
-                    unrespondedMembers: [],
-                    status: [],
-                    children: [],
-                  })),
+                  sortedSchichten.map((schicht) =>
+                    this.toPlaceholderSchicht(schicht),
+                  ),
                 );
               }),
             );
@@ -362,15 +367,9 @@ export class HelferDetailPage implements OnInit {
           // attendee data replaces the placeholder as soon as it resolves.
           return schichtenWithMembers$.pipe(
             startWith(
-              sortedSchichten.map((schicht) => ({
-                ...schicht,
-                attendees: [],
-                attendeeListTrue: [],
-                attendeeListFalse: [],
-                unrespondedMembers: [],
-                status: [],
-                children: [],
-              })),
+              sortedSchichten.map((schicht) =>
+                this.toPlaceholderSchicht(schicht),
+              ),
             ),
           );
         }),

--- a/src/app/pages/helfer/helfer-detail/helfer-detail.page.ts
+++ b/src/app/pages/helfer/helfer-detail/helfer-detail.page.ts
@@ -22,9 +22,11 @@ import {
   lastValueFrom,
   map,
   of,
+  startWith,
   switchMap,
   take,
   tap,
+  timeout,
 } from "rxjs";
 import { Browser } from "@capacitor/browser";
 import { HelferEvent, Schicht } from "src/app/models/event";
@@ -111,6 +113,7 @@ export class HelferDetailPage implements OnInit {
     this.schichten$ = this.getHelferEventSchichtenWithAttendees(
       this.event.clubId,
       this.event.id,
+      { eagerPlaceholder: true },
     );
   }
 
@@ -166,7 +169,11 @@ export class HelferDetailPage implements OnInit {
     );
   }
 
-  getHelferEventSchichtenWithAttendees(clubId: string, eventId: string) {
+  getHelferEventSchichtenWithAttendees(
+    clubId: string,
+    eventId: string,
+    options: { eagerPlaceholder?: boolean } = {},
+  ) {
     return this.eventService
       .getClubHelferEventSchichtenRef(clubId, eventId)
       .pipe(
@@ -182,147 +189,189 @@ export class HelferDetailPage implements OnInit {
             return (a.name || "").localeCompare(b.name || ""); // If timeFrom is the same, sort by name A-Z
           });
 
-          return this.fbService.getClubMemberRefs(clubId).pipe(
-            switchMap((clubMembers) => {
-              const clubMemberProfiles$ = clubMembers.map((member) =>
-                this.userProfileService.getUserProfileById(member.id).pipe(
-                  take(1),
-                  catchError((err) => {
-                    console.error(
-                      `Failed to fetch profile for club member ${member.id}:`,
-                      err,
-                    );
-                    return of({
-                      id: member.id,
-                      firstName: "Unknown",
-                      lastName: "Unknown",
-                      status: null,
-                      confirmed: null,
-                    });
-                  }),
-                ),
-              );
-              return forkJoin(clubMemberProfiles$).pipe(
-                switchMap((clubMembersWithDetails) => {
-                  const schichtenWithAttendees$ = sortedSchichten.map(
-                    (schicht) =>
-                      this.eventService
-                        .getClubHelferEventSchichtAttendeesRef(
-                          clubId,
-                          eventId,
-                          schicht.id,
-                        )
-                        .pipe(
-                          map((attendees) => {
-                            const attendeeDetails = attendees
-                              .map((attendee) => {
-                                const detail = clubMembersWithDetails.find(
-                                  (member) =>
-                                    member && member.id === attendee.id,
-                                );
-                                return detail
-                                  ? {
-                                      ...detail,
-                                      status: attendee.status,
-                                      confirmed: attendee.confirmed,
-                                      changedAt: attendee.changedAt,
-                                    }
-                                  : null;
-                              })
-                              .filter((item) => item); // Ensure nulls are removed
+          const schichtenWithMembers$ = this.fbService
+            .getClubMemberRefs(clubId)
+            .pipe(
+              switchMap((clubMembers) => {
+                const clubMemberProfiles$ = clubMembers.map((member) =>
+                  this.userProfileService.getUserProfileById(member.id).pipe(
+                    take(1),
+                    // A single stalled profile read must not block the whole
+                    // Schichten list forever.
+                    timeout(10000),
+                    catchError((err) => {
+                      console.error(
+                        `Failed to fetch profile for club member ${member.id}:`,
+                        err,
+                      );
+                      return of({
+                        id: member.id,
+                        firstName: "Unknown",
+                        lastName: "Unknown",
+                        status: null,
+                        confirmed: null,
+                      });
+                    }),
+                  ),
+                );
+                // forkJoin([]) completes without ever emitting, which would
+                // leave the Schichten list stuck on its loading state.
+                const clubMembersWithDetails$ =
+                  clubMemberProfiles$.length > 0
+                    ? forkJoin(clubMemberProfiles$)
+                    : of([]);
+                return clubMembersWithDetails$.pipe(
+                  switchMap((clubMembersWithDetails) => {
+                    const schichtenWithAttendees$ = sortedSchichten.map(
+                      (schicht) =>
+                        this.eventService
+                          .getClubHelferEventSchichtAttendeesRef(
+                            clubId,
+                            eventId,
+                            schicht.id,
+                          )
+                          .pipe(
+                            map((attendees) => {
+                              const attendeeDetails = attendees
+                                .map((attendee) => {
+                                  const detail = clubMembersWithDetails.find(
+                                    (member) =>
+                                      member && member.id === attendee.id,
+                                  );
+                                  return detail
+                                    ? {
+                                        ...detail,
+                                        status: attendee.status,
+                                        confirmed: attendee.confirmed,
+                                        changedAt: attendee.changedAt,
+                                      }
+                                    : null;
+                                })
+                                .filter((item) => item); // Ensure nulls are removed
 
-                            const attendeeListTrue = attendeeDetails.filter(
-                              (att) => att.status === true,
-                            );
-                            const attendeeListFalse = attendeeDetails.filter(
-                              (att) => att.status === false,
-                            );
-                            const respondedIds = new Set(
-                              attendeeDetails.map((att) => att.id),
-                            );
-                            const unrespondedMembers =
-                              clubMembersWithDetails.filter(
-                                (member) =>
-                                  member && !respondedIds.has(member.id),
+                              const attendeeListTrue = attendeeDetails.filter(
+                                (att) => att.status === true,
                               );
-
-                            return {
-                              ...schicht,
-                              attendees: attendeeDetails,
-                              attendeeListTrue,
-                              attendeeListFalse,
-                              unrespondedMembers,
-                              status: attendeeDetails
-                                .filter((att) =>
-                                  [
-                                    this.user.uid,
-                                    ...this.children.map((child) => child.id),
-                                  ].includes(att.id),
-                                )
-                                .map((att) => ({
-                                  id: att.id,
-                                  status: att.status,
-                                  confirmed: att.confirmed,
-                                  firstName: att.firstName,
-                                  lastName: att.lastName,
-                                  changedAt: att.changedAt,
-                                }))
-                                .sort(
-                                  (b, a) =>
-                                    a.changedAt.toDate().getTime() -
-                                    b.changedAt.toDate().getTime(),
-                                ),
-                              children: this.children.map((child) => {
-                                const attendeeData = attendeeDetails.find(
-                                  (att) => att.id === child.id,
+                              const attendeeListFalse = attendeeDetails.filter(
+                                (att) => att.status === false,
+                              );
+                              const respondedIds = new Set(
+                                attendeeDetails.map((att) => att.id),
+                              );
+                              const unrespondedMembers =
+                                clubMembersWithDetails.filter(
+                                  (member) =>
+                                    member && !respondedIds.has(member.id),
                                 );
-                                return {
-                                  id: child.id,
-                                  status: attendeeData?.status ?? null,
-                                  confirmed: attendeeData?.confirmed ?? false,
-                                  firstName: child.firstName,
-                                  lastName: child.lastName,
-                                  changedAt: attendeeData?.changedAt ?? null,
-                                };
-                              }),
-                            };
-                          }),
 
-                          catchError((err) => {
-                            console.error(
-                              "Error fetching attendees for schicht:",
-                              err,
-                            );
-                            return of({
-                              ...schicht,
-                              attendees: [],
-                              attendeeListTrue: [],
-                              attendeeListFalse: [],
-                              unrespondedMembers: clubMembersWithDetails,
-                              status: null,
-                              confirmed: null,
-                            });
-                          }),
-                        ),
-                  );
-                  return combineLatest(schichtenWithAttendees$);
-                }),
-              );
-            }),
-            catchError((err) => {
-              console.error("Error fetching club members:", err);
-              return of(
-                schichten.map((schicht) => ({
-                  ...schicht,
-                  attendees: [],
-                  attendeeListTrue: [],
-                  attendeeListFalse: [],
-                  unrespondedMembers: [],
-                  status: null,
-                  confirmed: null,
-                })),
-              );
-            }),
+                              return {
+                                ...schicht,
+                                attendees: attendeeDetails,
+                                attendeeListTrue,
+                                attendeeListFalse,
+                                unrespondedMembers,
+                                status: attendeeDetails
+                                  .filter((att) =>
+                                    [
+                                      // schichten$ can emit before event$ has
+                                      // resolved the authenticated user.
+                                      this.user?.uid,
+                                      ...this.children.map((child) => child.id),
+                                    ]
+                                      .filter(Boolean)
+                                      .includes(att.id),
+                                  )
+                                  .map((att) => ({
+                                    id: att.id,
+                                    status: att.status,
+                                    confirmed: att.confirmed,
+                                    firstName: att.firstName,
+                                    lastName: att.lastName,
+                                    changedAt: att.changedAt,
+                                  }))
+                                  .sort(
+                                    // changedAt can be missing on legacy
+                                    // attendee documents — never crash on it.
+                                    (b, a) =>
+                                      (a.changedAt?.toDate?.()?.getTime() ??
+                                        0) -
+                                      (b.changedAt?.toDate?.()?.getTime() ?? 0),
+                                  ),
+                                children: this.children.map((child) => {
+                                  const attendeeData = attendeeDetails.find(
+                                    (att) => att.id === child.id,
+                                  );
+                                  return {
+                                    id: child.id,
+                                    status: attendeeData?.status ?? null,
+                                    confirmed: attendeeData?.confirmed ?? false,
+                                    firstName: child.firstName,
+                                    lastName: child.lastName,
+                                    changedAt: attendeeData?.changedAt ?? null,
+                                  };
+                                }),
+                              };
+                            }),
+
+                            catchError((err) => {
+                              console.error(
+                                "Error fetching attendees for schicht:",
+                                err,
+                              );
+                              // The template reads status.length and children,
+                              // so the fallback must keep the same shape as a
+                              // successful emission (status: null crashed it).
+                              return of({
+                                ...schicht,
+                                attendees: [],
+                                attendeeListTrue: [],
+                                attendeeListFalse: [],
+                                unrespondedMembers: clubMembersWithDetails,
+                                status: [],
+                                children: [],
+                              });
+                            }),
+                          ),
+                    );
+                    return combineLatest(schichtenWithAttendees$);
+                  }),
+                );
+              }),
+              catchError((err) => {
+                console.error("Error fetching club members:", err);
+                return of(
+                  sortedSchichten.map((schicht) => ({
+                    ...schicht,
+                    attendees: [],
+                    attendeeListTrue: [],
+                    attendeeListFalse: [],
+                    unrespondedMembers: [],
+                    status: [],
+                    children: [],
+                  })),
+                );
+              }),
+            );
+
+          if (!options.eagerPlaceholder) {
+            return schichtenWithMembers$;
+          }
+          // Show the Schichten immediately with empty attendee lists instead
+          // of blocking the whole section on one profile read per club member
+          // (same non-blocking pattern as the Helfer list page). The real
+          // attendee data replaces the placeholder as soon as it resolves.
+          return schichtenWithMembers$.pipe(
+            startWith(
+              sortedSchichten.map((schicht) => ({
+                ...schicht,
+                attendees: [],
+                attendeeListTrue: [],
+                attendeeListFalse: [],
+                unrespondedMembers: [],
+                status: [],
+                children: [],
+              })),
+            ),
           );
         }),
         catchError((err) => {

--- a/src/app/pages/helfer/helfer-detail/helfer-detail.page.ts
+++ b/src/app/pages/helfer/helfer-detail/helfer-detail.page.ts
@@ -182,7 +182,6 @@ export class HelferDetailPage implements OnInit {
   private toPlaceholderSchicht(
     schicht: Schicht,
     unrespondedMembers: any[] = [],
-    pending: boolean = false,
   ) {
     return {
       ...schicht,
@@ -192,9 +191,10 @@ export class HelferDetailPage implements OnInit {
       unrespondedMembers,
       status: [],
       children: [],
-      // While pending, the attendee counts are not resolved yet, so the
-      // toggle handlers ignore taps (the capacity check would see 0).
-      pending,
+      // A placeholder — whether still loading or an error fallback — has no
+      // resolved attendee data, so the toggle/add handlers ignore taps on it
+      // (the capacity check would otherwise see 0 and allow overbooking).
+      pending: true,
     };
   }
 
@@ -385,7 +385,7 @@ export class HelferDetailPage implements OnInit {
           return schichtenWithMembers$.pipe(
             startWith(
               sortedSchichten.map((schicht) =>
-                this.toPlaceholderSchicht(schicht, [], true),
+                this.toPlaceholderSchicht(schicht),
               ),
             ),
           );

--- a/src/app/pages/helfer/helfer-detail/helfer-detail.page.ts
+++ b/src/app/pages/helfer/helfer-detail/helfer-detail.page.ts
@@ -111,9 +111,10 @@ export class HelferDetailPage implements OnInit {
     this.clubAdminList$ = this.fbService.getClubAdminList();
     // this.teamAdminList$ = this.fbService.getTeamAdminList();
 
-    // The template consumes schichten$ through two async pipes (member view
-    // and admin-edit view) — share one subscription so the member/profile
-    // read cascade doesn't run twice concurrently.
+    // schichten$ is consumed by async pipes in both the member view and the
+    // admin-edit view (mutually exclusive @if branches today) — share the
+    // subscription so any overlapping subscribers reuse one member/profile
+    // read cascade instead of each starting their own.
     this.schichten$ = this.getHelferEventSchichtenWithAttendees(
       this.event.clubId,
       this.event.id,
@@ -181,6 +182,7 @@ export class HelferDetailPage implements OnInit {
   private toPlaceholderSchicht(
     schicht: Schicht,
     unrespondedMembers: any[] = [],
+    pending: boolean = false,
   ) {
     return {
       ...schicht,
@@ -190,6 +192,9 @@ export class HelferDetailPage implements OnInit {
       unrespondedMembers,
       status: [],
       children: [],
+      // While pending, the attendee counts are not resolved yet, so the
+      // toggle handlers ignore taps (the capacity check would see 0).
+      pending,
     };
   }
 
@@ -380,7 +385,7 @@ export class HelferDetailPage implements OnInit {
           return schichtenWithMembers$.pipe(
             startWith(
               sortedSchichten.map((schicht) =>
-                this.toPlaceholderSchicht(schicht),
+                this.toPlaceholderSchicht(schicht, [], true),
               ),
             ),
           );
@@ -562,6 +567,11 @@ export class HelferDetailPage implements OnInit {
     memberId: string,
   ) {
     slidingItem.closeOpened();
+    // Placeholder rows have no resolved attendee counts yet — a tap in that
+    // window would bypass the capacity check below.
+    if (schicht?.pending) {
+      return;
+    }
     console.log("toggleSchichtItem", status, event, schicht, memberId);
 
     const newStartDate = event.date.toDate();
@@ -644,6 +654,11 @@ export class HelferDetailPage implements OnInit {
     event,
     schicht,
   ) {
+    // Placeholder rows have no resolved attendee counts yet — a tap in that
+    // window would bypass the capacity check below.
+    if (schicht?.pending) {
+      return;
+    }
     // Prüfe, ob schon genügend Helferinnen eingetragen sind (aber Admins dürfen überbuchen)
     if (
       schicht.attendeeListTrue &&

--- a/src/app/pages/helfer/helfer-detail/helfer-detail.page.ts
+++ b/src/app/pages/helfer/helfer-detail/helfer-detail.page.ts
@@ -1010,6 +1010,11 @@ export class HelferDetailPage implements OnInit {
 
   async addMembersToSchicht(slidingItem: IonItemSliding, schicht: any) {
     slidingItem.closeOpened();
+    // Placeholder rows have no resolved attendee list yet — the "available
+    // members" filter below would otherwise offer every club member.
+    if (schicht?.pending) {
+      return;
+    }
     // Hole alle Clubmitglieder
     const clubMembers = await firstValueFrom(
       this.fbService.getClubMemberRefs(this.event.clubId).pipe(

--- a/src/app/pages/helfer/helfer-detail/helfer-detail.page.ts
+++ b/src/app/pages/helfer/helfer-detail/helfer-detail.page.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectorRef,
   Component,
   Input,
+  OnDestroy,
   OnInit,
   ChangeDetectionStrategy,
 } from "@angular/core";
@@ -15,6 +16,7 @@ import { TranslateService } from "@ngx-translate/core";
 import { User } from "firebase/auth";
 import {
   Observable,
+  Subscription,
   catchError,
   combineLatest,
   firstValueFrom,
@@ -48,7 +50,7 @@ import { HelferAddPage } from "../helfer-add/helfer-add.page";
   changeDetection: ChangeDetectionStrategy.Eager,
   standalone: false,
 })
-export class HelferDetailPage implements OnInit {
+export class HelferDetailPage implements OnInit, OnDestroy {
   @Input() data!: HelferEvent;
   @Input() isFuture!: boolean;
 
@@ -56,6 +58,7 @@ export class HelferDetailPage implements OnInit {
 
   event$: Observable<any>;
   schichten$: Observable<any[]>;
+  private schichtenSub: Subscription;
 
   mode = "yes";
 
@@ -105,21 +108,37 @@ export class HelferDetailPage implements OnInit {
     if (!this.event) {
       return;
     }
+    // Build the streams only once: ngOnInit and ionViewWillEnter both call
+    // this, and rebuilding would run the whole read cascade twice per open
+    // (same guard as on the Helfer list page).
+    if (this.event$) {
+      return;
+    }
 
     this.event$ = this.getHelferEvent(this.event.clubId, this.event.id);
 
     this.clubAdminList$ = this.fbService.getClubAdminList();
     // this.teamAdminList$ = this.fbService.getTeamAdminList();
 
-    // schichten$ is consumed by async pipes in both the member view and the
-    // admin-edit view (mutually exclusive @if branches today) — share the
-    // subscription so any overlapping subscribers reuse one member/profile
-    // read cascade instead of each starting their own.
+    // schichten$ is consumed via async pipes in the member view and the
+    // admin-edit view — mutually exclusive @if branches, so on an edit
+    // toggle the subscriber count would briefly drop to 0 and a purely
+    // refCounted shareReplay would tear down and restart the whole read
+    // cascade (placeholder flash included). The component-held subscription
+    // below pins the stream for the page's lifetime; ngOnDestroy releases
+    // it so the Firestore listeners are cleaned up with the modal.
     this.schichten$ = this.getHelferEventSchichtenWithAttendees(
       this.event.clubId,
       this.event.id,
       { eagerPlaceholder: true },
     ).pipe(shareReplay({ bufferSize: 1, refCount: true }));
+    this.schichtenSub = this.schichten$.subscribe();
+  }
+
+  ngOnDestroy() {
+    if (this.schichtenSub) {
+      this.schichtenSub.unsubscribe();
+    }
   }
 
   isClubAdmin(clubAdminList: any[], clubId: string): boolean {

--- a/src/app/pages/helfer/helfer-detail/helfer-detail.page.ts
+++ b/src/app/pages/helfer/helfer-detail/helfer-detail.page.ts
@@ -22,6 +22,7 @@ import {
   lastValueFrom,
   map,
   of,
+  shareReplay,
   startWith,
   switchMap,
   take,
@@ -110,11 +111,14 @@ export class HelferDetailPage implements OnInit {
     this.clubAdminList$ = this.fbService.getClubAdminList();
     // this.teamAdminList$ = this.fbService.getTeamAdminList();
 
+    // The template consumes schichten$ through two async pipes (member view
+    // and admin-edit view) — share one subscription so the member/profile
+    // read cascade doesn't run twice concurrently.
     this.schichten$ = this.getHelferEventSchichtenWithAttendees(
       this.event.clubId,
       this.event.id,
       { eagerPlaceholder: true },
-    );
+    ).pipe(shareReplay({ bufferSize: 1, refCount: true }));
   }
 
   isClubAdmin(clubAdminList: any[], clubId: string): boolean {
@@ -174,7 +178,10 @@ export class HelferDetailPage implements OnInit {
    * status.length, children and the attendee lists unconditionally, so every
    * emission (eager placeholder or error fallback) must carry this shape.
    */
-  private toPlaceholderSchicht(schicht: any, unrespondedMembers: any[] = []) {
+  private toPlaceholderSchicht(
+    schicht: Schicht,
+    unrespondedMembers: any[] = [],
+  ) {
     return {
       ...schicht,
       attendees: [],

--- a/src/app/pages/helfer/helfer-detail/helfer-detail.page.ts
+++ b/src/app/pages/helfer/helfer-detail/helfer-detail.page.ts
@@ -194,7 +194,7 @@ export class HelferDetailPage implements OnInit {
     return this.eventService
       .getClubHelferEventSchichtenRef(clubId, eventId)
       .pipe(
-        switchMap((schichten) => {
+        switchMap((schichten, schichtenEmissionIndex) => {
           if (schichten.length === 0) return of([]); // No schichten found
 
           // Sort the schichten by timeFrom ascending and then by name A-Z
@@ -358,13 +358,18 @@ export class HelferDetailPage implements OnInit {
               }),
             );
 
-          if (!options.eagerPlaceholder) {
+          if (!options.eagerPlaceholder || schichtenEmissionIndex > 0) {
             return schichtenWithMembers$;
           }
           // Show the Schichten immediately with empty attendee lists instead
           // of blocking the whole section on one profile read per club member
           // (same non-blocking pattern as the Helfer list page). The real
           // attendee data replaces the placeholder as soon as it resolves.
+          // Only on the FIRST schichten emission: the collection ref is a live
+          // listener, and replaying the placeholder on later emissions would
+          // flash every viewer's list back to "unanswered" whenever a Schicht
+          // document changes — the async pipe keeps the last resolved state
+          // on screen instead.
           return schichtenWithMembers$.pipe(
             startWith(
               sortedSchichten.map((schicht) =>


### PR DESCRIPTION
Fixes #257

## Problem

Die Helferliste «hängt immer wieder»: Im Helfer-Detail-Modal erscheinen nur die Event-Details, die Schichten-Liste lädt nie, und es kommt wiederholt eine Fehlermeldung (gemeldet für Helfer-Event `dYT4m48vvJeHL0w2HrKL`, mehrheitlich im Browser genutzt).

## Ursachen

Die Pipeline `getHelferEventSchichtenWithAttendees()` konnte auf mehreren Wegen hängen bleiben oder das Template crashen:

1. `forkJoin([])` completed ohne Emission, wenn die Clubmitglieder-Liste leer ist → `schichten$` emittiert nie, die Sektion bleibt für immer leer.
2. Ein Firestore-Read **pro Clubmitglied**, und `forkJoin` wartet ohne Timeout auf alle → bei grossen Clubs/instabiler Verbindung bleibt die Liste beliebig lange leer.
3. `changedAt.toDate()` wirft bei Attendee-Dokumenten ohne `changedAt`.
4. Die `catchError`-Fallbacks lieferten `status: null` ohne `children` — das Template liest aber `schicht.status.length`, wodurch jede Change Detection erneut wirft (die wiederkehrende Meldung) und die Ansicht eingefroren bleibt.
5. `schichten$` kann emittieren, bevor `event$` `this.user` gesetzt hat (`this.user.uid` → TypeError → Fallback → Punkt 4).

## Änderungen

- **Sofort rendern:** Die Schichten erscheinen unmittelbar mit leeren Attendee-Listen (`startWith`-Platzhalter, nur beim initialen Laden — Live-Updates flackern nicht auf den Platzhalter zurück); die Profil-Joins füllen sie nach — gleiches non-blocking Muster wie auf den Listen-Seiten (29278ef). `confirmSchichten()` wartet weiterhin auf die echten Daten.
- **`forkJoin`-Guard:** Leere Mitgliederliste → `of([])` statt nie emittierendem `forkJoin([])`.
- **`timeout(10000)`** pro Profil-Read; bei Timeout/Fehler greift der «Unknown»-Platzhalter statt dass die ganze Liste blockiert.
- **Nullsicherer Sort:** `changedAt?.toDate?.()?.getTime() ?? 0`.
- **Template-sichere Fallbacks:** zentral in `toPlaceholderSchicht()` (`status: []`, `children: []` statt `status: null`), damit `schicht.status.length` nie mehr wirft.
- **`pending`-Guard:** Platzhalter- und Fehler-Fallback-Zeilen sind nicht interaktiv — Taps können die Kapazitätsprüfung nicht mehr mit leeren Attendee-Listen umgehen (`toggleSchicht`, `toggleSchichtItem`, `addMembersToSchicht`).
- **Stream-Lebensdauer:** `schichten$` wird per shareReplay geteilt und über eine komponenten-eigene Subscription für die Seiten-Lebensdauer gepinnt (Freigabe in `ngOnDestroy`) — der Edit-Toggle zwischen den beiden `@if`-Zweigen startet die Lesekaskade nicht mehr neu. `loadData()` baut die Streams nur noch einmal (ngOnInit + ionViewWillEnter starteten sie doppelt).
- **`this.user?.uid`** mit `filter(Boolean)` gegen die Race mit `event$`.

## Tests

- Spec-Grundlage repariert: Der `AuthService`-Spy kannte `getAuthenticatedUser$` nicht — **alle 24 Tests der Suite waren rot** (gleiches Problem in 13 weiteren Specs → #260). Spy ergänzt.
- 9 neue Regressionstests: leere Mitgliederliste, fehlendes `changedAt`, Fehler-Fallbacks (template-sicher und nicht interaktiv), Eager-Platzhalter (sofort, kein Replay bei Live-Updates, langsame Mitgliederliste), 10s-Timeout-Pfad (`fakeAsync`), Taps auf pending-Zeilen, keine Kaskaden-Neustarts bei Re-Subscription/View-Re-Entry.
- `ng test` (helfer-detail-Suite): **33/33 grün**; `ng build`: erfolgreich (AOT/strictTemplates).

Follow-ups: #259 (Profil-Lookups bündeln/cachen statt N Reads pro Clubmitglied), #260 (veraltete AuthService-Spies in 13 weiteren Specs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FkgikK428UwuRY3RJ6FMUM