### PR TITLE
feat(championship): Team-Filter für Meisterschaftsspiele

### DIFF
--- a/src/app/pages/championship/championship/championship.page.html
+++ b/src/app/pages/championship/championship/championship.page.html
@@ -10,38 +10,16 @@
     <ion-buttons slot="secondary">
       <ion-button (click)="close()">{{"common.close" | translate}}</ion-button>
     </ion-buttons>
+    } @if (!team && (hasMultipleTeams$ | async)) {
+    <ion-buttons slot="end">
+      <ion-button (click)="openTeamFilter()">
+        <ion-icon
+          slot="icon-only"
+          [name]="isTeamFilterActive ? 'filter-circle' : 'filter-circle-outline'"
+        ></ion-icon>
+      </ion-button>
+    </ion-buttons>
     }
-    <!--<ion-buttons slot="end">
-    <ion-button id="championshipMoreButton">
-      <ion-icon slot="icon-only" name="ellipsis-horizontal-outline"></ion-icon>
-    </ion-button>
-    <ion-popover trigger="championshipMoreButton" size="auto">
-      <ng-template>
-        <ion-content class="ion-padding">
-          <ion-list>
-            <ion-list-header>
-              <ion-note>
-                Alle Spiele
-              </ion-note>
-            </ion-list-header>
-            <ion-item type="button" detail="true">
-              <ion-icon slot="start" name="checkmark-circle" color="success">
-              </ion-icon>
-              <ion-label>
-                zusagen
-              </ion-label></ion-item>
-              <ion-item type="button" detail="true">
-                <ion-icon slot="start" name="close-circle" color="danger">
-                </ion-icon>
-                <ion-label>
-                  absagen
-                </ion-label>
-              </ion-item>
-            </ion-list>
-          </ion-content>
-        </ng-template>
-      </ion-popover>
-    </ion-buttons>-->
   </ion-toolbar>
   <ion-toolbar>
     <ion-segment [(ngModel)]="mode">
@@ -70,7 +48,15 @@
       </ion-buttons>
     </ion-toolbar>
   </ion-header>
-  @if (mode=='games') { @if (gameList$ | async; as gameList) { @if
+  @if (isTeamFilterActive) {
+  <ion-item lines="none">
+    <ion-chip (click)="clearTeamFilter()">
+      <ion-icon name="filter-circle"></ion-icon>
+      <ion-label>{{currentTeamName}}</ion-label>
+      <ion-icon name="close-circle"></ion-icon>
+    </ion-chip>
+  </ion-item>
+  } @if (mode=='games') { @if (filteredGameList$ | async; as gameList) { @if
   (gameList.length > 0) {
   <ion-list lines="full">
     <ion-list-header>
@@ -244,8 +230,8 @@
     </ion-item>
     }
   </ion-list>
-  } @if (gameListPast$ | async; as gameListPast) { @if (gameListPast.length > 0)
-  {
+  } @if (filteredGameListPast$ | async; as gameListPast) { @if
+  (gameListPast.length > 0) {
   <ion-list lines="full">
     <ion-list-header>
       <ion-label>{{"championship.past__games" | translate}}</ion-label>

--- a/src/app/pages/championship/championship/championship.page.spec.ts
+++ b/src/app/pages/championship/championship/championship.page.spec.ts
@@ -258,7 +258,7 @@ describe("ChampionshipPage", () => {
     // Der Filter wird in Preferences (localStorage) gespeichert — nicht in
     // andere Tests durchsickern lassen.
     afterEach(async () => {
-      await Preferences.clear();
+      await Preferences.remove({ key: "championshipTeamFilter" });
     });
 
     it("passes all games through while no team is selected", async () => {

--- a/src/app/pages/championship/championship/championship.page.spec.ts
+++ b/src/app/pages/championship/championship/championship.page.spec.ts
@@ -3,12 +3,13 @@ import { ChampionshipPage } from "./championship.page";
 import { CUSTOM_ELEMENTS_SCHEMA, ChangeDetectorRef } from "@angular/core";
 import { TranslateModule, TranslateService } from "@ngx-translate/core";
 import { RouterTestingModule } from "@angular/router/testing";
-import { lastValueFrom, of } from "rxjs";
+import { lastValueFrom, of, take } from "rxjs";
 import { AuthService } from "src/app/services/auth.service";
 import { FirebaseService } from "src/app/services/firebase.service";
 import { ChampionshipService } from "src/app/services/firebase/championship.service";
 import { UserProfileService } from "src/app/services/firebase/user-profile.service";
 import { UiService } from "src/app/services/ui.service";
+import { Preferences } from "@capacitor/preferences";
 import { SwissUnihockeyService } from "src/app/services/swiss-unihockey.service";
 import {
   ModalController,
@@ -32,6 +33,7 @@ describe("ChampionshipPage", () => {
     const fbServiceSpy = jasmine.createSpyObj("FirebaseService", [
       "getClubAdminList",
       "getTeamAdminList",
+      "getTeamList",
       "getUserTeamRefs",
       "getTeamMemberRefs",
       "getTeamRef",
@@ -40,6 +42,18 @@ describe("ChampionshipPage", () => {
     ]);
     fbServiceSpy.getClubAdminList.and.returnValue(of([]));
     fbServiceSpy.getTeamAdminList.and.returnValue(of([]));
+    fbServiceSpy.getTeamList.and.returnValue(of([]));
+    // ngOnInit kann über die Change Detection laufen (z.B. nach einem
+    // awaited Preferences-Aufruf) — loadData() muss dann ohne Fehler durchlaufen.
+    const swissUnihockeySpy = jasmine.createSpyObj("SwissUnihockeyService", [
+      "getTeamRankings",
+      "getCurrentSeason",
+    ]);
+    swissUnihockeySpy.getCurrentSeason.and.returnValue(of(2026));
+    const userProfileSpy = jasmine.createSpyObj("UserProfileService", [
+      "getChildren",
+    ]);
+    userProfileSpy.getChildren.and.returnValue(of([]));
 
     await TestBed.configureTestingModule({
       declarations: [ChampionshipPage],
@@ -56,10 +70,7 @@ describe("ChampionshipPage", () => {
             "setTeamGameAttendeeStatus",
           ]),
         },
-        {
-          provide: UserProfileService,
-          useValue: jasmine.createSpyObj("UserProfileService", ["getChildren"]),
-        },
+        { provide: UserProfileService, useValue: userProfileSpy },
         {
           provide: UiService,
           useValue: jasmine.createSpyObj("UiService", [
@@ -67,16 +78,11 @@ describe("ChampionshipPage", () => {
             "showErrorToast",
             "showInfoDialog",
             "showConfirmDialog",
+            "showFormDialog",
             "showActionSheet",
           ]),
         },
-        {
-          provide: SwissUnihockeyService,
-          useValue: jasmine.createSpyObj("SwissUnihockeyService", [
-            "getTeamRankings",
-            "getCurrentSeason",
-          ]),
-        },
+        { provide: SwissUnihockeyService, useValue: swissUnihockeySpy },
         {
           provide: ModalController,
           useValue: jasmine.createSpyObj("ModalController", [
@@ -143,7 +149,7 @@ describe("ChampionshipPage", () => {
       uiService.showInfoDialog.and.resolveTo();
       uiService.showConfirmDialog.and.resolveTo(true);
 
-      component.gameList$ = of([
+      component.filteredGameList$ = of([
         // Frist 24h, Spiel heute 00:00 Uhr -> Abmeldefrist abgelaufen
         {
           id: "g-late",
@@ -220,6 +226,57 @@ describe("ChampionshipPage", () => {
         championshipService.setTeamGameAttendeeStatus,
       ).not.toHaveBeenCalled();
       expect(uiService.showSuccessToast).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("team filter", () => {
+    const games = [
+      { id: "g-1", teamId: "team-1" },
+      { id: "g-2", teamId: "team-2" },
+    ] as any[];
+
+    // Der Filter wird in Preferences (localStorage) gespeichert — nicht in
+    // andere Tests durchsickern lassen.
+    afterEach(async () => {
+      await Preferences.clear();
+    });
+
+    it("passes all games through while no team is selected", async () => {
+      const result = await lastValueFrom(
+        component["filterByTeam"](of(games)).pipe(take(1)),
+      );
+
+      expect(component.isTeamFilterActive).toBeFalse();
+      expect(result.map((game) => game.id)).toEqual(["g-1", "g-2"]);
+    });
+
+    it("only shows the selected team and can be cleared again", async () => {
+      const filtered$ = component["filterByTeam"](of(games));
+
+      component["setTeamFilter"]("team-2", "Team 2");
+      expect(component.isTeamFilterActive).toBeTrue();
+      expect(component.currentTeamName).toBe("Team 2");
+      let result = await lastValueFrom(filtered$.pipe(take(1)));
+      expect(result.map((game) => game.id)).toEqual(["g-2"]);
+
+      await component.clearTeamFilter();
+      expect(component.isTeamFilterActive).toBeFalse();
+      result = await lastValueFrom(filtered$.pipe(take(1)));
+      expect(result.map((game) => game.id)).toEqual(["g-1", "g-2"]);
+    });
+
+    it("applies the team chosen in the filter dialog", async () => {
+      const uiService = TestBed.inject(UiService) as jasmine.SpyObj<UiService>;
+      component.teamList$ = of([
+        { id: "team-1", name: "Team 1" },
+        { id: "team-2", name: "Team 2" },
+      ] as any);
+      uiService.showFormDialog.and.resolveTo({ values: "team-2" });
+
+      await component.openTeamFilter();
+
+      expect(component.currentTeamFilter).toBe("team-2");
+      expect(component.currentTeamName).toBe("Team 2");
     });
   });
 });

--- a/src/app/pages/championship/championship/championship.page.spec.ts
+++ b/src/app/pages/championship/championship/championship.page.spec.ts
@@ -207,7 +207,7 @@ describe("ChampionshipPage", () => {
     });
 
     it("shows no success toast when every item is past the deadline", async () => {
-      component.gameList$ = of([
+      component.filteredGameList$ = of([
         {
           id: "g-late",
           teamId: "team-1",

--- a/src/app/pages/championship/championship/championship.page.ts
+++ b/src/app/pages/championship/championship/championship.page.ts
@@ -29,6 +29,7 @@ import {
   tap,
   shareReplay,
   startWith,
+  BehaviorSubject,
 } from "rxjs";
 import { Game } from "src/app/models/game";
 import { AuthService } from "src/app/services/auth.service";
@@ -46,6 +47,10 @@ import { Profile } from "src/app/models/user";
 import { UiService } from "src/app/services/ui.service";
 import { SwissUnihockeyService } from "src/app/services/swiss-unihockey.service";
 import { shareLatest } from "src/app/services/share-latest";
+import { Preferences } from "@capacitor/preferences";
+
+const ALL_TEAMS = "all";
+const TEAM_FILTER_STORAGE_KEY = "championshipTeamFilter";
 
 @Component({
   selector: "app-championship",
@@ -63,29 +68,24 @@ export class ChampionshipPage implements OnInit {
 
   gameList$!: Observable<Game[]>;
   gameListPast$!: Observable<Game[]>;
+  filteredGameList$!: Observable<Game[]>;
+  filteredGameListPast$!: Observable<Game[]>;
   teamRankings$!: Observable<any[]>;
   teamsWithRankings$!: Observable<any[]>;
 
-  /*gameListBackup$: Observable<Game[]>;
-  gameListPastBackup$: Observable<Game[]>;
-  teamRankingsBackup$: Observable<any[]>;
-
-
-  gameListBackup: Subscription;
-  gameListPastBackup: Subscription;
-  */
-
   mode = "games";
-
-  teamList$!: Observable<Team[]>;
 
   clubAdminList$!: Observable<Club[]>;
   teamAdminList$!: Observable<Team[]>;
 
   children: Profile[] = [];
-  /*filterList: any[] = [];
-  filterValue: string = "";
-  */
+
+  // Team-Filter der Spielliste (Auswahl wird lokal gespeichert)
+  teamList$!: Observable<Team[]>;
+  hasMultipleTeams$!: Observable<boolean>;
+  currentTeamFilter: string = ALL_TEAMS;
+  currentTeamName: string = "";
+  private teamFilter$ = new BehaviorSubject<string>(ALL_TEAMS);
 
   constructor(
     public toastController: ToastController,
@@ -108,6 +108,9 @@ export class ChampionshipPage implements OnInit {
 
   ngOnInit() {
     this.loadData();
+
+    // Nicht awaiten: der Filter wird reaktiv über teamFilter$ nachgezogen.
+    void this.restoreTeamFilter();
   }
 
   ionViewWillEnter() {
@@ -128,12 +131,21 @@ export class ChampionshipPage implements OnInit {
       shareReplay({ bufferSize: 1, refCount: true }),
     );
 
+    // FILTER
+    this.teamList$ = this.fbService.getTeamList();
+    this.hasMultipleTeams$ = this.teamList$.pipe(
+      map((teams) => teams.length > 1),
+    );
+    this.filteredGameList$ = this.filterByTeam(this.gameList$);
+    this.filteredGameListPast$ = this.filterByTeam(this.gameListPast$);
+
     // Get dynamic season from Swiss Unihockey API
     this.swissUnihockeyService.getCurrentSeason().subscribe((season) => {
       console.log("Current season:", season);
       this.teamRankings$ = this.getTeamsWithRankingsForYear(season.toString());
       // Create filtered observable for teams with actual ranking data
-      this.teamsWithRankings$ = this.teamRankings$.pipe(
+      // (zusätzlich auf das gewählte Team eingeschränkt)
+      this.teamsWithRankings$ = this.filterByTeam(this.teamRankings$).pipe(
         map((teams) =>
           teams.filter(
             (entry) =>
@@ -158,6 +170,118 @@ export class ChampionshipPage implements OnInit {
   }
   isTeamAdmin(teamAdminList: any[], teamId: string): boolean {
     return this.fbService.isTeamAdmin(teamAdminList, teamId);
+  }
+
+  /**
+   * Schränkt eine Liste (Spiele oder Tabellen-Einträge) auf das gewählte
+   * Team ein; ohne Filter wird die Liste unverändert durchgereicht.
+   */
+  private filterByTeam<T extends { teamId: string }>(
+    items$: Observable<T[]>,
+  ): Observable<T[]> {
+    return combineLatest([items$, this.teamFilter$]).pipe(
+      map(([items, teamId]) =>
+        teamId === ALL_TEAMS
+          ? items
+          : items.filter((item) => item.teamId === teamId),
+      ),
+    );
+  }
+
+  get isTeamFilterActive(): boolean {
+    return this.currentTeamFilter !== ALL_TEAMS;
+  }
+
+  /**
+   * Öffnet die Team-Auswahl und übernimmt den gewählten Filter.
+   */
+  async openTeamFilter() {
+    const teams = await lastValueFrom(this.teamList$.pipe(take(1)));
+
+    const result = await this.uiService.showFormDialog({
+      header: await lastValueFrom(
+        this.translate.get("championship.filter__title"),
+      ),
+      inputs: [
+        {
+          type: "radio",
+          label: await lastValueFrom(
+            this.translate.get("championship.all_games"),
+          ),
+          value: ALL_TEAMS,
+          checked: this.currentTeamFilter === ALL_TEAMS,
+        },
+        ...teams.map((team) => ({
+          type: "radio",
+          label: team.name,
+          value: team.id,
+          checked: this.currentTeamFilter === team.id,
+        })),
+      ],
+      confirmText: await lastValueFrom(this.translate.get("common.apply")),
+      cancelText: await lastValueFrom(this.translate.get("common.cancel")),
+    });
+
+    const selectedId = result?.values;
+    if (typeof selectedId !== "string") return;
+
+    const selectedTeam = teams.find((team) => team.id === selectedId);
+    this.setTeamFilter(
+      selectedTeam ? selectedTeam.id : ALL_TEAMS,
+      selectedTeam ? selectedTeam.name : "",
+    );
+    await this.saveTeamFilter();
+  }
+
+  async clearTeamFilter() {
+    this.setTeamFilter(ALL_TEAMS, "");
+    await this.saveTeamFilter();
+  }
+
+  private setTeamFilter(teamId: string, teamName: string) {
+    this.currentTeamFilter = teamId;
+    this.currentTeamName = teamName;
+    this.teamFilter$.next(teamId);
+  }
+
+  /**
+   * Stellt den zuletzt gewählten Team-Filter wieder her. Ein gespeichertes Team,
+   * dem der Benutzer nicht mehr angehört, wird verworfen — sonst bliebe die
+   * Liste dauerhaft leer.
+   */
+  private async restoreTeamFilter(): Promise<void> {
+    if (this.team && this.team.id) return;
+
+    try {
+      const { value } = await Preferences.get({ key: TEAM_FILTER_STORAGE_KEY });
+      if (!value || value === ALL_TEAMS) return;
+
+      const teams = await lastValueFrom(this.teamList$.pipe(take(1)));
+      const savedTeam = teams.find((team) => team.id === value);
+      if (!savedTeam) {
+        await Preferences.remove({ key: TEAM_FILTER_STORAGE_KEY });
+        return;
+      }
+
+      this.setTeamFilter(savedTeam.id, savedTeam.name);
+    } catch (error) {
+      console.error("Error restoring team filter:", error);
+    }
+  }
+
+  private async saveTeamFilter(): Promise<void> {
+    try {
+      if (this.currentTeamFilter === ALL_TEAMS) {
+        await Preferences.remove({ key: TEAM_FILTER_STORAGE_KEY });
+      } else {
+        await Preferences.set({
+          key: TEAM_FILTER_STORAGE_KEY,
+          value: this.currentTeamFilter,
+        });
+      }
+    } catch (error) {
+      console.error("Error saving team filter:", error);
+    }
   }
 
   getTeamsWithRankingsForYear(year: string) {
@@ -760,7 +884,11 @@ export class ChampionshipPage implements OnInit {
    */
   async toggleAllGames(status: boolean) {
     try {
-      const gameList = await lastValueFrom(this.gameList$.pipe(take(1)));
+      // Bewusst die gefilterte Liste: die Aktion gilt für das, was der
+      // Benutzer gerade sieht.
+      const gameList = await lastValueFrom(
+        this.filteredGameList$.pipe(take(1)),
+      );
       if (gameList.length === 0) return;
 
       const confirmed = await this.confirmToggleAll(status, gameList.length);
@@ -1024,66 +1152,4 @@ export class ChampionshipPage implements OnInit {
     slidingItem.closeOpened();
     this.processToggle(childrenId, status, game);
   }
-  /*  async openFilter(ev: Event) {
-
-    const alertInputs = [];
-    for (const item of this.filterList) {
-      alertInputs.push({
-        label: item.name,
-        type: 'radio',
-        checked: item.id == this.filterValue,
-        value: item.id,
-      });
-    }
-
-    let alert = await this.alertCtrl.create({
-      header: 'News filtern',
-      message: 'Nach Verein oder Teams filtern.',
-      // subHeader: 'Nach Verein oder Teams filtern.',
-      inputs: alertInputs,
-      buttons: [
-        {
-          text: "OK",
-          role: "confirm",
-          handler: (value) => {
-            console.log(value)
-            this.filterValue = value;
-            
-            this.gameList$ = this.gameListBackup$.pipe(
-              map(items => {
-               return items.filter(element => element.teamId == value)
-              })
-            )  
-            this.gameListPast$ = this.gameListPastBackup$.pipe(
-              map(items => {
-               return items.filter(element => element.teamId == value)
-              })
-            )          
-            this.teamRankings$ = this.teamRankingsBackup$.pipe(
-              map(items => {
-               return items.filter(element => element.teamId == value)
-              })
-            )   
-          }
-        },
-        {
-          text: "abbrechen",
-          role: "cancel",
-          handler:async  (value) => {
-            console.log(value);
-            this.filterValue = "";
-            await Preferences.set({
-              key: 'teamFilter',
-              value: this.filterValue,
-            });
-            this.gameList$ = this.gameListBackup$;
-            this.gameListPast$ = this.gameListPastBackup$;
-            this.teamRankings$ = this.teamRankingsBackup$;
-          }
-        }
-      ],
-      htmlAttributes: { 'aria-label': 'alert dialog' },
-    });
-    alert.present();
-  }*/
 }

--- a/src/assets/lang/de.json
+++ b/src/assets/lang/de.json
@@ -311,6 +311,8 @@
     "upcomming__games": "Kommende Spiele",
     "alle_anmelden__confirm": "Bist du sicher, dass du dich für die kommenden {{count}} Meisterschaftsspiele anmelden willst?",
     "alle_abmelden__confirm": "Bist du sicher, dass du dich von den kommenden {{count}} Meisterschaftsspielen abmelden willst?",
+    "all_games": "Alle Spiele",
+    "filter__title": "Spiele filtern",
     "create_game_confirm": "Möchten Sie dieses Spiel wirklich erstellen?",
     "actions": "Meisterschaft Aktionen"
   },

--- a/src/assets/lang/en.json
+++ b/src/assets/lang/en.json
@@ -310,6 +310,8 @@
     "upcomming__games": "Upcoming games",
     "alle_anmelden__confirm": "Are you sure you want to register for the next {{count}} championship games?",
     "alle_abmelden__confirm": "Are you sure you want to unregister from the next {{count}} championship games?",
+    "all_games": "All games",
+    "filter__title": "Filter games",
     "actions": "Championship Actions",
     "create_game_confirm": "Do you really want to create this game?"
   },

--- a/src/assets/lang/fr.json
+++ b/src/assets/lang/fr.json
@@ -309,6 +309,8 @@
     "upcomming__games": "Jeux à venir",
     "alle_anmelden__confirm": "Es-tu sûr de vouloir t'inscrire aux {{count}} prochains matchs de championnat ?",
     "alle_abmelden__confirm": "Es-tu sûr de vouloir te désinscrire des {{count}} prochains matchs de championnat ?",
+    "all_games": "Tous les matchs",
+    "filter__title": "Filtrer les matchs",
     "actions": "Actions du championnat",
     "create_game_confirm": "Voulez-vous vraiment créer ce match ?"
   },

--- a/src/assets/lang/it.json
+++ b/src/assets/lang/it.json
@@ -309,6 +309,8 @@
     "upcomming__games": "Prossime partite",
     "alle_anmelden__confirm": "Sei sicuro di volerti iscrivere alle prossime {{count}} partite di campionato?",
     "alle_abmelden__confirm": "Sei sicuro di volerti disiscrivere dalle prossime {{count}} partite di campionato?",
+    "all_games": "Tutte le partite",
+    "filter__title": "Filtra partite",
     "actions": "Azioni campionato",
     "create_game_confirm": "Vuoi davvero creare questa partita?"
   },


### PR DESCRIPTION
## Zusammenfassung

Die Meisterschaftsseite erhält denselben Team-Filter wie die Trainingsliste.

- Filter-Icon in der Toolbar (nur sichtbar, wenn der Benutzer mehr als ein Team hat), Team-Auswahl per Dialog, aktiver Filter als Chip mit Reset.
- Der Filter wirkt auf kommende und vergangene Spiele sowie auf die Tabelle.
- Die Auswahl wird lokal in den Preferences gespeichert (`championshipTeamFilter`) und beim nächsten Öffnen wiederhergestellt; ein gespeichertes Team, dem der Benutzer nicht mehr angehört, wird verworfen.
- **alle anmelden / alle abmelden** beziehen sich neu auf die gefilterte Liste, also auf das, was der Benutzer gerade sieht.
- Der alte, auskommentierte Filter-Entwurf und der auskommentierte Popover-Block im Header wurden entfernt. Neue Texte in de/fr/it/en.

## Abhängigkeit

Gestapelt auf #261 (`feat/alle-abmelden`), weil beide Änderungen `toggleAllGames()` anfassen. Bitte zuerst den ersten PR mergen; dieser PR zeigt dann nur noch den Filter-Commit.

## Tests

- Unit-Tests für Durchreichen ohne Filter, Einschränken auf ein Team + Reset via Chip, Übernahme der Dialog-Auswahl.
- `ng test` für `championship.page.spec.ts` und `trainings.page.spec.ts` grün (13 Tests), `ng build` (Dev) erfolgreich.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
