### PR TITLE
perf(firestore): persistenten Offline-Cache (IndexedDB) app-weit aktivieren

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,12 @@ Quellcode der Tools unter `tools/`:
   `production`, das Firebase-Hosting-Target `app-myclub`. Das ist in
   `themes.config.json` über `hostingTarget` abgebildet — nicht "aufräumen".
 - **`npm run themes:sync` nach jeder Config-Änderung**, sonst schlägt CI an.
+- **Firestore läuft mit persistentem Cache (IndexedDB)**, siehe
+  `firestoreFactory()` in `src/app/app.module.ts`. Dokumente überleben einen
+  App-Neustart; `getDocFromCache`/`getDocsFromCache` stehen zur Verfügung.
+  Beim Logout terminiert `AuthService.logout()` den Client, leert den Cache
+  und lädt die App neu — nach `terminate()` darf nichts mehr auf Firestore
+  zugreifen.
 - Generierte JSON-Dateien werden mit dem Prettier des Projekts formatiert,
   damit der husky-Pre-Commit-Hook sie nicht erneut anfasst.
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -26,7 +26,13 @@ import {
 import { FontAwesomeModule } from "@fortawesome/angular-fontawesome";
 
 import { provideFirebaseApp, getApp, initializeApp } from "@angular/fire/app";
-import { getFirestore, provideFirestore } from "@angular/fire/firestore";
+import {
+  provideFirestore,
+  initializeFirestore,
+  persistentLocalCache,
+  persistentMultipleTabManager,
+  persistentSingleTabManager,
+} from "@angular/fire/firestore";
 import { provideAuth, getAuth, initializeAuth } from "@angular/fire/auth";
 import { indexedDBLocalPersistence } from "firebase/auth";
 import { provideStorage, getStorage } from "@angular/fire/storage";
@@ -85,6 +91,35 @@ import { CreateNewsPage } from "./pages/news/create-news/create-news.page";
 import { MemberInvoiceListPage } from "./pages/member-invoice-list/member-invoice-list.page";
 import { QrInvoiceModalPage } from "./pages/qr-invoice-modal/qr-invoice-modal.page";
 import { UserListItemComponent } from "./components/user-list-item/user-list-item.component";
+
+/**
+ * Firestore with a persistent (IndexedDB) cache instead of the default
+ * memory-only cache.
+ *
+ * Why: with the memory cache every app start re-reads every document the
+ * pages listen to, and Firestore bills each of those reads. With the
+ * persistent cache the documents survive restarts, listeners that are
+ * re-attached within 30 minutes only receive changes, and the app can render
+ * cached data while offline. If IndexedDB is unavailable (private mode, old
+ * WebViews) the SDK logs a warning and falls back to the memory cache by
+ * itself, so this never blocks the start.
+ *
+ * The native apps run in a single WebView, so they use the lighter
+ * single-tab manager; the PWA can be open in several browser tabs, which
+ * must share one cache.
+ *
+ * Logout terminates this client and clears the cache (see AuthService), so
+ * the next account on the same device never sees the previous user's data.
+ */
+export function firestoreFactory() {
+  return initializeFirestore(getApp(), {
+    localCache: persistentLocalCache({
+      tabManager: Capacitor.isNativePlatform()
+        ? persistentSingleTabManager(undefined)
+        : persistentMultipleTabManager(),
+    }),
+  });
+}
 
 export function HttpLoaderFactory(httpClient: HttpClient) {
   return new TranslateHttpLoader(httpClient, "./assets/lang/", ".json");
@@ -199,7 +234,7 @@ const getConfig = () => {
   ],
   providers: [
     provideFirebaseApp(() => initializeApp(environment.firebase)),
-    provideFirestore(() => getFirestore()),
+    provideFirestore(firestoreFactory),
     provideAuth(() => {
       if (Capacitor.isNativePlatform()) {
         return initializeAuth(getApp(), {

--- a/src/app/services/auth.service.spec.ts
+++ b/src/app/services/auth.service.spec.ts
@@ -89,6 +89,16 @@ describe("AuthService", () => {
     it("should expose logout$ observable", () => {
       expect(service.logout$).toBeDefined();
     });
+
+    it("should not reload the app when the Firestore client cannot be terminated", async () => {
+      // firestoreSpy is not a real Firestore instance, so terminate() rejects.
+      const reloadSpy = spyOn(service, "reloadApp");
+
+      const terminated = await (service as any).clearFirestorePersistence();
+
+      expect(terminated).toBeFalse();
+      expect(reloadSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe("validateAndRefreshToken", () => {

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -27,6 +27,7 @@ import {
   doc,
   setDoc,
   clearIndexedDbPersistence,
+  terminate,
 } from "@angular/fire/firestore";
 
 /******************************************************************************************
@@ -186,19 +187,9 @@ export class AuthService {
       // 2. Sign out from Firebase Auth
       await signOut(this.auth);
 
-      // 3. Clear Firebase Firestore persistence
-      try {
-        await clearIndexedDbPersistence(this.firestore);
-        console.log("Firebase persistence cleared successfully");
-      } catch (error) {
-        // This might fail if there are active listeners, which is normal
-        console.log(
-          "Could not clear Firebase persistence (normal if listeners are active):",
-          error.message,
-        );
-      }
-
-      // 4. Navigate to logout page
+      // 3. Navigate to the logout page first: leaving the tabs destroys the
+      //    pages and with them their Firestore listeners, before the client
+      //    below is terminated.
       const navLogout = await this.router.navigateByUrl("/logout");
       if (navLogout) {
         console.log("Navigation success to Logout Page");
@@ -206,11 +197,53 @@ export class AuthService {
         console.error("Navigation ERROR to Logout Page");
       }
 
+      // 4. Clear the persistent Firestore cache (IndexedDB). Documents cached
+      //    for this account must not be served to the next account on the
+      //    same device. A terminated client cannot be restarted, so the app is
+      //    reloaded on the logout page to get a fresh one.
+      const terminated = await this.clearFirestorePersistence();
+      if (terminated) {
+        this.reloadApp();
+      }
+
       return true;
     } catch (error) {
       console.error("Error during logout:", error);
       throw error;
     }
+  }
+
+  /**
+   * Terminates the Firestore client and clears its persistent cache.
+   * clearIndexedDbPersistence() only works on a terminated client.
+   *
+   * Returns whether the client was terminated — the caller must reload the
+   * app in that case, even when clearing failed (e.g. another browser tab
+   * still holds the cache): after terminate() every Firestore call throws.
+   */
+  private async clearFirestorePersistence(): Promise<boolean> {
+    try {
+      await runInInjectionContext(this.injector, () =>
+        terminate(this.firestore),
+      );
+    } catch (error) {
+      console.warn("Could not terminate Firestore client:", error?.message);
+      return false;
+    }
+    try {
+      await runInInjectionContext(this.injector, () =>
+        clearIndexedDbPersistence(this.firestore),
+      );
+      console.log("Firestore persistence cleared");
+    } catch (error) {
+      console.warn("Could not clear Firestore persistence:", error?.message);
+    }
+    return true;
+  }
+
+  /** Full reload; kept separate so tests can stub it. */
+  reloadApp(): void {
+    window.location.reload();
   }
 
   /**


### PR DESCRIPTION
## Zusammenfassung

Firestore lief bisher nur mit dem Memory-Cache: Bei jedem App-Start wurden alle Dokumente, auf die die Seiten hören, neu vom Server gelesen und abgerechnet. Dieser PR aktiviert den **persistenten Offline-Cache (IndexedDB)** app-weit und sorgt dafür, dass er beim Logout wirklich geleert wird.

- `provideFirestore()` nutzt `initializeFirestore()` mit `persistentLocalCache`: im Browser mit dem Multi-Tab-Manager (mehrere PWA-Tabs teilen einen Cache), in den nativen Apps mit dem leichteren Single-Tab-Manager. Fehlt IndexedDB (privater Modus, alte WebViews), fällt das SDK selbst auf den Memory-Cache zurück.
- Dokumente überleben damit einen Neustart, innerhalb von 30 Minuten wieder angehängte Listener erhalten nur noch Änderungen, und die App kann offline gecachte Daten anzeigen.
- **Logout:** Bisher rief `logout()` `clearIndexedDbPersistence()` auf einem laufenden Client auf, was immer mit `failed-precondition` fehlschlug und nur geloggt wurde. Mit persistentem Cache hätten die Daten des abgemeldeten Kontos dem nächsten Konto auf demselben Gerät (z.B. Eltern/Kind) aus dem Cache gedient. Der Logout navigiert jetzt zuerst auf die Logout-Seite (baut Tab-Seiten und Listener ab), terminiert den Firestore-Client, leert den Cache und lädt die App neu, weil ein terminierter Client nicht neu gestartet werden kann. Schlägt `terminate()` fehl, bleibt es beim bisherigen Verhalten ohne Reload.
- CLAUDE.md dokumentiert den Cache und die Regel, dass nach `terminate()` nichts mehr auf Firestore zugreifen darf.

Hinweis: Der Import von `persistentLocalCache` existierte früher ungenutzt und wurde in 4de58f1 entfernt; aktiv war die Persistenz nie.

## Verhaltensänderungen, die man kennen sollte

- Beim Logout wird die App neu geladen (Web und nativ).
- `getDocFromCache` / `getDocsFromCache` stehen jetzt zur Verfügung; Listener, die nach mehr als 30 Minuten wieder angehängt werden, lesen weiterhin neu.

## Verifikation

- `auth.service.spec.ts` grün (16 Tests, inkl. neuem Test: kein Reload, wenn der Client nicht terminiert werden kann), `ng build` (Dev) erfolgreich.
- Im Browser verifiziert: IndexedDB `firestore/[DEFAULT]/myclubmanagement/main` wird angelegt.
- **Nicht auf nativen Geräten (iOS/Android) getestet.** Vor einem Store-Release bitte Logout/Login-Wechsel auf einem Gerät prüfen.

Refs #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)
