### PR TITLE
chore(android): ungenutzte Google-Maps-Gradle-Variablen entfernen

### DIFF
--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -13,10 +13,6 @@ ext {
     androidxJunitVersion = '1.2.1'
     androidxEspressoCoreVersion = '3.6.1'
     cordovaAndroidVersion = '10.1.1'
-    googleMapsPlayServicesVersion = '18.2.0'
-    googleMapsUtilsVersion='3.8.2'
-    googleMapsKtxVersion="5.0.0"
-    googleMapsUtilsKtxVersion="5.0.0"
     kotlinxCoroutinesVersion="1.7.3"
     androidxCoreKTXVersion="1.12.0"
     kotlin_version="1.9.25"


### PR DESCRIPTION
Entfernt die vier `googleMaps*Version`-Variablen aus `android/variables.gradle`. Google Maps wurde mit #252 durch SwissTopo/MapLibre ersetzt; die Variablen werden nirgends mehr referenziert.

Refs: myclubapp/backend#106

🤖 Generated with [Claude Code](https://claude.com/claude-code)