### PR TITLE
fix(profile): Mitglieder-Profil-Memo robust gegen Cache-Antworten, Abbrüche und eigene Änderungen

### DIFF
--- a/src/app/services/firebase/user-profile.service.spec.ts
+++ b/src/app/services/firebase/user-profile.service.spec.ts
@@ -36,16 +36,18 @@ describe("UserProfileService", () => {
   describe("getMemberProfiles", () => {
     const profile = (id: string, firstName: string) =>
       ({ id, firstName, lastName: "L", roles: ["profile-role"] }) as any;
+    /** Answer for one batch: every id except "missing" has a profile. */
+    const batch = (ids: string[], fromCache = false) => ({
+      profiles: ids
+        .filter((id) => id !== "missing")
+        .map((id) => profile(id, "N-" + id)),
+      fromCache,
+    });
     let fetchSpy: jasmine.Spy;
 
     beforeEach(() => {
       fetchSpy = spyOn(service as any, "fetchProfiles").and.callFake(
-        (ids: string[]) =>
-          of(
-            ids
-              .filter((id) => id !== "missing")
-              .map((id) => profile(id, "N-" + id)),
-          ),
+        (ids: string[]) => of(batch(ids)),
       );
     });
 
@@ -121,9 +123,7 @@ describe("UserProfileService", () => {
       fetchSpy.and.returnValue(throwError(() => new Error("offline")));
       service.getMemberProfiles([{ id: "a" }]).subscribe((result) => {
         expect(result[0].firstName).toBe("Unknown");
-        fetchSpy.and.callFake((ids: string[]) =>
-          of(ids.map((id) => profile(id, "N-" + id))),
-        );
+        fetchSpy.and.callFake((ids: string[]) => of(batch(ids)));
         service.getMemberProfiles([{ id: "a" }]).subscribe((retry) => {
           expect(fetchSpy).toHaveBeenCalledTimes(2);
           expect(retry[0].firstName).toBe("N-a");
@@ -190,6 +190,29 @@ describe("UserProfileService", () => {
             done();
           });
       });
+    });
+
+    it("does not memoise ids missing from a cache-served answer", (done) => {
+      // Offline (or reconnecting) Firestore answers from IndexedDB with the
+      // profiles it happens to hold; "b" may well exist on the server.
+      fetchSpy.and.returnValue(
+        of({ profiles: [profile("a", "N-a")], fromCache: true }),
+      );
+      service
+        .getMemberProfiles([{ id: "a" }, { id: "b" }])
+        .subscribe((first) => {
+          expect(first.map((m) => m.firstName)).toEqual(["N-a", "Unknown"]);
+          fetchSpy.and.callFake((ids: string[]) => of(batch(ids)));
+          service
+            .getMemberProfiles([{ id: "a" }, { id: "b" }])
+            .subscribe((second) => {
+              // "a" comes from the memo, only "b" is asked again.
+              expect(fetchSpy).toHaveBeenCalledTimes(2);
+              expect(fetchSpy.calls.argsFor(1)[0]).toEqual(["b"]);
+              expect(second.map((m) => m.firstName)).toEqual(["N-a", "N-b"]);
+              done();
+            });
+        });
     });
   });
 });

--- a/src/app/services/firebase/user-profile.service.spec.ts
+++ b/src/app/services/firebase/user-profile.service.spec.ts
@@ -4,6 +4,7 @@ import { Firestore } from "@angular/fire/firestore";
 import { Storage } from "@angular/fire/storage";
 import { AuthService } from "../auth.service";
 import { Injector } from "@angular/core";
+import { TranslateService } from "@ngx-translate/core";
 import { Subject, of, throwError } from "rxjs";
 
 describe("UserProfileService", () => {
@@ -23,6 +24,13 @@ describe("UserProfileService", () => {
         {
           provide: Injector,
           useValue: jasmine.createSpyObj("Injector", ["get"]),
+        },
+        {
+          provide: TranslateService,
+          useValue: {
+            instant: (key: string) =>
+              key === "common.unknown" ? "Unknown" : key,
+          },
         },
       ],
     });
@@ -270,6 +278,17 @@ describe("UserProfileService", () => {
           done();
         });
       });
+    });
+
+    it("treats whitespace-only names as unknown without reading", (done) => {
+      service
+        .getMemberProfiles([{ id: "a", firstName: " ", lastName: "Müller" }])
+        .subscribe((result) => {
+          expect(fetchSpy).not.toHaveBeenCalled();
+          expect(result[0].firstName).toBe("Unknown");
+          expect(result[0].lastName).toBe("Müller");
+          done();
+        });
     });
   });
 });

--- a/src/app/services/firebase/user-profile.service.spec.ts
+++ b/src/app/services/firebase/user-profile.service.spec.ts
@@ -4,7 +4,7 @@ import { Firestore } from "@angular/fire/firestore";
 import { Storage } from "@angular/fire/storage";
 import { AuthService } from "../auth.service";
 import { Injector } from "@angular/core";
-import { of, throwError } from "rxjs";
+import { Subject, of, throwError } from "rxjs";
 
 describe("UserProfileService", () => {
   let service: UserProfileService;
@@ -213,6 +213,63 @@ describe("UserProfileService", () => {
               done();
             });
         });
+    });
+
+    it("shares an in-flight read between concurrent calls", (done) => {
+      const pending = new Subject<any>();
+      fetchSpy.and.returnValue(pending);
+      const names: string[] = [];
+      const collect = (result: any[]) => {
+        names.push(result[0].firstName);
+        if (names.length === 2) {
+          expect(fetchSpy).toHaveBeenCalledTimes(1);
+          expect(names).toEqual(["N-a", "N-a"]);
+          done();
+        }
+      };
+      service.getMemberProfiles([{ id: "a" }]).subscribe(collect);
+      service.getMemberProfiles([{ id: "a" }]).subscribe(collect);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      pending.next(batch(["a"]));
+      pending.complete();
+    });
+
+    it("keeps the result of a read whose subscriber went away", (done) => {
+      const pending = new Subject<any>();
+      fetchSpy.and.returnValue(pending);
+      // A switchMap on a live member list tears the read down mid-flight;
+      // the read is billed either way, so its result must land in the memo.
+      service
+        .getMemberProfiles([{ id: "a" }])
+        .subscribe()
+        .unsubscribe();
+      pending.next(batch(["a"]));
+      pending.complete();
+      fetchSpy.and.callFake((ids: string[]) => of(batch(ids)));
+      // The promise chain writes the memo in microtasks; read after them.
+      setTimeout(() => {
+        service.getMemberProfiles([{ id: "a" }]).subscribe((result) => {
+          expect(fetchSpy).toHaveBeenCalledTimes(1);
+          expect(result[0].firstName).toBe("N-a");
+          done();
+        });
+      });
+    });
+
+    it("does not let a read started before clearCache repopulate the memo", (done) => {
+      const pending = new Subject<any>();
+      fetchSpy.and.returnValue(pending);
+      service.getMemberProfiles([{ id: "a" }]).subscribe();
+      service.clearCache(); // logout
+      pending.next(batch(["a"]));
+      pending.complete();
+      fetchSpy.and.callFake((ids: string[]) => of(batch(ids)));
+      setTimeout(() => {
+        service.getMemberProfiles([{ id: "a" }]).subscribe(() => {
+          expect(fetchSpy).toHaveBeenCalledTimes(2);
+          done();
+        });
+      });
     });
   });
 });

--- a/src/app/services/firebase/user-profile.service.ts
+++ b/src/app/services/firebase/user-profile.service.ts
@@ -32,9 +32,8 @@ import {
 
 import {
   Observable,
-  catchError,
   defer,
-  forkJoin,
+  firstValueFrom,
   from,
   map,
   of,
@@ -110,6 +109,18 @@ export class UserProfileService {
     string,
     { profile: Profile | null; readAt: number }
   >();
+  /**
+   * Batched reads still in flight, per member id. Concurrent callers await
+   * the same read instead of issuing their own, and because the read writes
+   * the memo itself, its result is kept even when the page that started it
+   * has already moved on (switchMap on a live member list).
+   */
+  private pendingProfileReads = new Map<string, Promise<void>>();
+  /**
+   * Bumped by clearCache() so that a read started before a logout cannot
+   * repopulate the memo afterwards.
+   */
+  private memberProfileGeneration = 0;
 
   /**
    * Clears all cached data - should be called on logout
@@ -117,6 +128,8 @@ export class UserProfileService {
   clearCache(): void {
     this.profileCache.clear();
     this.memberProfileCache.clear();
+    this.pendingProfileReads.clear();
+    this.memberProfileGeneration++;
   }
 
   constructor(
@@ -256,71 +269,99 @@ export class UserProfileService {
     if (!members || members.length === 0) {
       return of([]);
     }
-    const now = Date.now();
-    const missingIds = [
-      ...new Set(
-        members
-          .filter((member) => !hasDenormalizedName(member))
-          .map((member) => member.id)
-          .filter((id) => {
-            const cached = this.memberProfileCache.get(id);
-            return !cached || now - cached.readAt > this.PROFILE_GRACE_MS;
-          }),
-      ),
-    ];
-    const batches$ = chunk(
-      missingIds,
-      UserProfileService.PROFILE_BATCH_SIZE,
-    ).map((ids) =>
-      defer(() => this.fetchProfiles(ids)).pipe(
-        map(({ profiles, fromCache }) => ({ ids, profiles, fromCache })),
-        catchError((error) => {
-          console.error(
-            `Failed to fetch ${ids.length} member profiles:`,
-            error,
-          );
-          return of({
-            ids: [] as string[],
-            profiles: [] as Profile[],
-            fromCache: false,
-          });
-        }),
-      ),
-    );
-    const fetched$: Observable<
-      { ids: string[]; profiles: Profile[]; fromCache: boolean }[]
-    > = batches$.length > 0 ? forkJoin(batches$) : of([]);
-
-    return fetched$.pipe(
-      map((batches) => {
-        const readAt = Date.now();
-        for (const { ids, profiles, fromCache } of batches) {
-          const byId = new Map(
-            profiles.map((profile) => [profile.id, profile]),
-          );
-          for (const id of ids) {
-            const profile = byId.get(id);
-            // A cached answer may just not contain the profile yet — leave
-            // the id unmemoised so the next open asks the server.
-            if (!profile && fromCache) {
-              continue;
-            }
-            this.memberProfileCache.set(id, {
-              profile: profile ?? null,
-              readAt,
-            });
-          }
-        }
-        return members.map((member) =>
+    return defer(() => {
+      const now = Date.now();
+      const missingIds = [
+        ...new Set(
+          members
+            .filter((member) => !hasDenormalizedName(member))
+            .map((member) => member.id)
+            .filter((id) => {
+              const cached = this.memberProfileCache.get(id);
+              return !cached || now - cached.readAt > this.PROFILE_GRACE_MS;
+            }),
+        ),
+      ];
+      const reads = this.readProfiles(missingIds);
+      return reads.length > 0 ? from(Promise.all(reads)) : of(null);
+    }).pipe(
+      map(() =>
+        members.map((member) =>
           this.mergeMemberProfile(
             member,
             hasDenormalizedName(member)
               ? null
               : (this.memberProfileCache.get(member.id)?.profile ?? null),
           ),
-        );
-      }),
+        ),
+      ),
     );
+  }
+
+  /**
+   * Starts the batched reads for the `ids` that are not already in flight
+   * and returns one promise per read to wait for. Each read memoises its
+   * own result, so nothing is lost when the subscriber is gone by then.
+   */
+  private readProfiles(ids: string[]): Promise<void>[] {
+    const reads = new Set<Promise<void>>();
+    const idsToRead: string[] = [];
+    for (const id of ids) {
+      const inFlight = this.pendingProfileReads.get(id);
+      if (inFlight) {
+        reads.add(inFlight);
+      } else {
+        idsToRead.push(id);
+      }
+    }
+    const generation = this.memberProfileGeneration;
+    for (const batch of chunk(
+      idsToRead,
+      UserProfileService.PROFILE_BATCH_SIZE,
+    )) {
+      const read: Promise<void> = firstValueFrom(this.fetchProfiles(batch))
+        .then((result) => {
+          if (generation === this.memberProfileGeneration) {
+            this.memoiseProfiles(batch, result);
+          }
+        })
+        .catch((error) => {
+          // Not memoised, so the next open retries.
+          console.error(
+            `Failed to fetch ${batch.length} member profiles:`,
+            error,
+          );
+        })
+        .finally(() => {
+          for (const id of batch) {
+            if (this.pendingProfileReads.get(id) === read) {
+              this.pendingProfileReads.delete(id);
+            }
+          }
+        });
+      for (const id of batch) {
+        this.pendingProfileReads.set(id, read);
+      }
+      reads.add(read);
+    }
+    return [...reads];
+  }
+
+  private memoiseProfiles(
+    ids: string[],
+    { profiles, fromCache }: ProfileBatch,
+  ): void {
+    const readAt = Date.now();
+    const byId = new Map(profiles.map((profile) => [profile.id, profile]));
+    for (const id of ids) {
+      const profile = byId.get(id);
+      // A cached answer may just not contain the profile yet — leave the id
+      // unmemoised so the next open asks the server.
+      if (!profile && fromCache) {
+        continue;
+      }
+      this.memberProfileCache.set(id, { profile: profile ?? null, readAt });
+    }
   }
 
   /** One `documentId() in` read for up to PROFILE_BATCH_SIZE ids. */

--- a/src/app/services/firebase/user-profile.service.ts
+++ b/src/app/services/firebase/user-profile.service.ts
@@ -39,6 +39,7 @@ import {
   of,
   takeUntil,
 } from "rxjs";
+import { TranslateService } from "@ngx-translate/core";
 import { Profile } from "../../models/user";
 import { Photo } from "@capacitor/camera";
 
@@ -55,10 +56,12 @@ import { shareLatest } from "../share-latest";
  */
 function hasDenormalizedName(member: object): boolean {
   const { firstName, lastName } = member as Partial<Profile>;
-  return (
-    (typeof firstName === "string" && firstName.trim() !== "") ||
-    (typeof lastName === "string" && lastName.trim() !== "")
-  );
+  return isNonBlank(firstName) || isNonBlank(lastName);
+}
+
+/** A name counts as known only if it contains more than whitespace. */
+function isNonBlank(value: unknown): value is string {
+  return typeof value === "string" && value.trim() !== "";
 }
 
 /** Splits `items` into consecutive slices of at most `size` elements. */
@@ -136,6 +139,7 @@ export class UserProfileService {
     private firestore: Firestore,
     private readonly storage: Storage,
     private readonly authService: AuthService,
+    private readonly translate: TranslateService,
   ) {
     // Aktiviere Offline Persistenz
     // Listen to logout events to clear cache
@@ -258,7 +262,7 @@ export class UserProfileService {
    * member listener, so the detail pages of a club cost no profile reads.
    *
    * A batch that cannot be read (permission denied, no connection and no
-   * cache) yields "Unknown" for its members and is not memoised, so the
+   * cache) yields "Unbekannt" for its members and is not memoised, so the
    * next open retries. The same goes for ids missing from an answer that
    * Firestore served from its local cache: only a server answer proves that
    * a profile does not exist. Profiles must never block an attendee list.
@@ -391,14 +395,17 @@ export class UserProfileService {
     profile: Profile | null,
   ): T & Profile {
     // Without a profile read the names come from the member document itself
-    // (denormalised by the backend) — or stay "Unknown".
+    // (denormalised by the backend) — or fall back to "Unbekannt" in the
+    // user's language. Whitespace-only names count as missing, like in
+    // hasDenormalizedName().
     const names = profile ?? (member as Partial<Profile>);
+    const unknown = this.translate.instant("common.unknown");
     return {
       ...member,
       ...(profile ?? {}),
       id: member.id,
-      firstName: names.firstName || "Unknown",
-      lastName: names.lastName || "Unknown",
+      firstName: isNonBlank(names.firstName) ? names.firstName : unknown,
+      lastName: isNonBlank(names.lastName) ? names.lastName : unknown,
       // Team/club roles live on the member document, not on the profile.
       roles: (member as { roles?: string[] }).roles ?? [],
     } as unknown as T & Profile;

--- a/src/app/services/firebase/user-profile.service.ts
+++ b/src/app/services/firebase/user-profile.service.ts
@@ -71,6 +71,18 @@ function chunk<T>(items: T[], size: number): T[][] {
   return slices;
 }
 
+/** Result of one batched profile read, see UserProfileService.fetchProfiles. */
+interface ProfileBatch {
+  profiles: Profile[];
+  /**
+   * True when Firestore answered from the local cache (offline, or the
+   * roughly 10 s reconnect window in which the SDK marks itself offline).
+   * Such an answer proves only the profiles it contains — an id missing
+   * from it may simply not have been cached yet.
+   */
+  fromCache: boolean;
+}
+
 @Injectable({
   providedIn: "root",
 })
@@ -232,9 +244,11 @@ export class UserProfileService {
    * members, attendees) are not read at all: their names come from the live
    * member listener, so the detail pages of a club cost no profile reads.
    *
-   * A batch that cannot be read (offline without cache, permission denied)
-   * yields "Unknown" names for its members and is not memoised, so the next
-   * open retries. Profiles must never block an attendee list.
+   * A batch that cannot be read (permission denied, no connection and no
+   * cache) yields "Unknown" for its members and is not memoised, so the
+   * next open retries. The same goes for ids missing from an answer that
+   * Firestore served from its local cache: only a server answer proves that
+   * a profile does not exist. Profiles must never block an attendee list.
    */
   getMemberProfiles<T extends { id: string }>(
     members: T[],
@@ -259,29 +273,40 @@ export class UserProfileService {
       UserProfileService.PROFILE_BATCH_SIZE,
     ).map((ids) =>
       defer(() => this.fetchProfiles(ids)).pipe(
-        map((profiles) => ({ ids, profiles })),
+        map(({ profiles, fromCache }) => ({ ids, profiles, fromCache })),
         catchError((error) => {
           console.error(
             `Failed to fetch ${ids.length} member profiles:`,
             error,
           );
-          return of({ ids: [] as string[], profiles: [] as Profile[] });
+          return of({
+            ids: [] as string[],
+            profiles: [] as Profile[],
+            fromCache: false,
+          });
         }),
       ),
     );
-    const fetched$: Observable<{ ids: string[]; profiles: Profile[] }[]> =
-      batches$.length > 0 ? forkJoin(batches$) : of([]);
+    const fetched$: Observable<
+      { ids: string[]; profiles: Profile[]; fromCache: boolean }[]
+    > = batches$.length > 0 ? forkJoin(batches$) : of([]);
 
     return fetched$.pipe(
       map((batches) => {
         const readAt = Date.now();
-        for (const { ids, profiles } of batches) {
+        for (const { ids, profiles, fromCache } of batches) {
           const byId = new Map(
             profiles.map((profile) => [profile.id, profile]),
           );
           for (const id of ids) {
+            const profile = byId.get(id);
+            // A cached answer may just not contain the profile yet — leave
+            // the id unmemoised so the next open asks the server.
+            if (!profile && fromCache) {
+              continue;
+            }
             this.memberProfileCache.set(id, {
-              profile: byId.get(id) ?? null,
+              profile: profile ?? null,
               readAt,
             });
           }
@@ -299,7 +324,7 @@ export class UserProfileService {
   }
 
   /** One `documentId() in` read for up to PROFILE_BATCH_SIZE ids. */
-  protected fetchProfiles(ids: string[]): Observable<Profile[]> {
+  protected fetchProfiles(ids: string[]): Observable<ProfileBatch> {
     return runInInjectionContext(this.injector, () =>
       from(
         getDocs(
@@ -310,12 +335,13 @@ export class UserProfileService {
         ),
       ),
     ).pipe(
-      map((snapshot) =>
-        snapshot.docs.map((document) => ({
+      map((snapshot) => ({
+        profiles: snapshot.docs.map((document) => ({
           ...(document.data() as Profile),
           id: document.id,
         })),
-      ),
+        fromCache: snapshot.metadata.fromCache,
+      })),
     );
   }
 

--- a/src/app/services/firebase/user-profile.service.ts
+++ b/src/app/services/firebase/user-profile.service.ts
@@ -415,18 +415,27 @@ export class UserProfileService {
 
     await updateProfile(user, { photoURL: url });
 
-    const userProfileRef = doc(this.firestore, `userProfile/${user.uid}`);
-    return updateDoc(userProfileRef, { profilePicture: url });
+    return this.updateOwnProfile({ profilePicture: url });
   }
 
   async setUserProfile(userProfile: Profile) {
     const user = this.authService.auth.currentUser;
-    const userProfileRef = doc(this.firestore, `userProfile/${user.uid}`);
     await updateProfile(user, {
       displayName: userProfile.firstName + " " + userProfile.lastName,
     });
 
-    return updateDoc(userProfileRef, { userProfile });
+    return this.updateOwnProfile({ userProfile });
+  }
+
+  /**
+   * Writes `fields` to the signed-in user's profile document and drops the
+   * user's memoised member profile: getMemberProfiles() would otherwise show
+   * the old name or picture on team pages for up to PROFILE_GRACE_MS.
+   */
+  private updateOwnProfile(fields: { [field: string]: unknown }) {
+    const user = this.authService.auth.currentUser;
+    this.memberProfileCache.delete(user.uid);
+    return updateDoc(doc(this.firestore, `userProfile/${user.uid}`), fields);
   }
 
   getPushDeviceList(): Observable<DocumentData[]> {
@@ -478,56 +487,38 @@ export class UserProfileService {
   }
 
   async changeSettingsPush(state: boolean) {
-    const user = this.authService.auth.currentUser;
-    const userProfileRef = doc(this.firestore, `userProfile/${user.uid}`);
-    return updateDoc(userProfileRef, { settingsPush: state });
+    return this.updateOwnProfile({ settingsPush: state });
   }
   async changeSettingsPushModule(state: boolean, module) {
-    const user = this.authService.auth.currentUser;
-    const userProfileRef = doc(this.firestore, `userProfile/${user.uid}`);
-    return updateDoc(userProfileRef, { ["settingsPush" + module]: state });
+    return this.updateOwnProfile({ ["settingsPush" + module]: state });
   }
 
   async changeSettingsEmail(state: boolean) {
-    const user = this.authService.auth.currentUser;
-    const userProfileRef = doc(this.firestore, `userProfile/${user.uid}`);
-    return updateDoc(userProfileRef, { settingsEmail: state });
+    return this.updateOwnProfile({ settingsEmail: state });
   }
 
   async changeSettingsEmailReporting(state: boolean) {
-    const user = this.authService.auth.currentUser;
-    const userProfileRef = doc(this.firestore, `userProfile/${user.uid}`);
-    return updateDoc(userProfileRef, { settingsEmailReporting: state });
+    return this.updateOwnProfile({ settingsEmailReporting: state });
   }
 
   async changeShowGamePreview(state: boolean) {
-    const user = this.authService.auth.currentUser;
-    const userProfileRef = doc(this.firestore, `userProfile/${user.uid}`);
-    return updateDoc(userProfileRef, { showGamePreview: state });
+    return this.updateOwnProfile({ showGamePreview: state });
   }
 
   async changeGamePreviewDays(days: number) {
-    const user = this.authService.auth.currentUser;
-    const userProfileRef = doc(this.firestore, `userProfile/${user.uid}`);
-    return updateDoc(userProfileRef, { gamePreviewDays: days });
+    return this.updateOwnProfile({ gamePreviewDays: days });
   }
 
   async changeHideEmail(state: boolean) {
-    const user = this.authService.auth.currentUser;
-    const userProfileRef = doc(this.firestore, `userProfile/${user.uid}`);
-    return updateDoc(userProfileRef, { hideEmail: state });
+    return this.updateOwnProfile({ hideEmail: state });
   }
 
   async changeHidePhoneNumber(state: boolean) {
-    const user = this.authService.auth.currentUser;
-    const userProfileRef = doc(this.firestore, `userProfile/${user.uid}`);
-    return updateDoc(userProfileRef, { hidePhoneNumber: state });
+    return this.updateOwnProfile({ hidePhoneNumber: state });
   }
 
   changeProfileAttribute(value: any, fieldname) {
-    const user = this.authService.auth.currentUser;
-    const userProfileRef = doc(this.firestore, `userProfile/${user.uid}`);
-    return updateDoc(userProfileRef, { [fieldname]: value });
+    return this.updateOwnProfile({ [fieldname]: value });
   }
 
   async deleteChild(userId: string, childId: string) {

--- a/src/assets/lang/de.json
+++ b/src/assets/lang/de.json
@@ -143,6 +143,7 @@
     "logout": "Logout",
     "profile": "Profil",
     "loading": "Wird geladen",
+    "unknown": "Unbekannt",
     "training": "Training",
     "probe": "Probe",
     "events": "Events",

--- a/src/assets/lang/en.json
+++ b/src/assets/lang/en.json
@@ -129,6 +129,7 @@
     "logout": "Logout",
     "profile": "Profile",
     "loading": "Loading",
+    "unknown": "Unknown",
     "training": "Training",
     "probe": "Practice",
     "events": "Events",

--- a/src/assets/lang/fr.json
+++ b/src/assets/lang/fr.json
@@ -128,6 +128,7 @@
     "logout": "Déconnexion",
     "profile": "Profil",
     "loading": "Chargement",
+    "unknown": "Inconnu",
     "training": "Entraînement",
     "probe": "Répétition",
     "events": "Événements",

--- a/src/assets/lang/it.json
+++ b/src/assets/lang/it.json
@@ -128,6 +128,7 @@
     "logout": "Esci",
     "profile": "Profilo",
     "loading": "Caricamento",
+    "unknown": "Sconosciuto",
     "training": "Allenamento",
     "probe": "Prova",
     "events": "Eventi",


### PR DESCRIPTION
## Problem

Review-Befunde zu #268 (`UserProfileService.getMemberProfiles`):

- `getDocs()` antwortet offline und im Reconnect-Fenster (rund 10 s) aus dem lokalen Cache und liefert nur die Profile, die IndexedDB gerade hält. Jede fehlende Id wurde zehn Minuten als "kein Profil" memoisiert; die Mitglieder blieben auch nach dem Reconnect "Unknown". Der Fehlerpfad griff nicht, weil nichts fehlschlägt.
- Das Memo wurde erst nach `forkJoin` geschrieben. Brach eine Seite den Read per `switchMap` ab (Live-Listener der Mitgliederliste emittiert erneut, oder `ngOnInit`/`ionViewWillEnter` bauen den Stream doppelt), war `getDocs()` abgerechnet, das Ergebnis aber verloren. Gleichzeitige Aufrufer lasen ebenfalls doppelt.
- Eigene Profiländerungen (Name, Bild, Einstellungen) haben das Memo nicht invalidiert; Team-Seiten zeigten bis zu zehn Minuten den alten Stand.
- Der Platzhalter "Unknown" war fest verdrahtet, und Namen aus lauter Leerzeichen galten in `hasDenormalizedName()` als fehlend, im Merge aber als vorhanden.

## Änderung

Ein Commit pro Thema:

- `fetchProfiles()` liefert `snapshot.metadata.fromCache` mit; fehlende Ids einer Cache-Antwort werden nicht memoisiert, gefundene Profile schon.
- Jeder Batch-Read ist ein Promise, das sein Ergebnis selbst memoisiert und pro Id als "in flight" registriert ist. Gleichzeitige Aufrufer teilen den Read, abgebrochene Subscriber verlieren nichts. `clearCache()` (Logout) erhöht eine Generation, damit ein davor gestarteter Read das Memo nicht wieder füllt.
- Alle Schreibzugriffe auf das eigene Profil laufen über `updateOwnProfile()`, das den Memo-Eintrag des Benutzers verwirft.
- `mergeMemberProfile()` nutzt `common.unknown` (de/fr/it/en) und dieselbe Leerzeichen-Prüfung wie `hasDenormalizedName()`.

Die Security Rules sind geprüft: `allow read: if isSignedIn()` auf `userProfile` deckt `list` ab.

## Test

`npx ng test --no-watch --browsers=ChromeHeadless`: 241 of 241 SUCCESS (fünf neue Service-Tests: Cache-Antwort, geteilter Read, Read nach Abbruch, Read vor `clearCache`, Leerzeichen-Namen). Jeder Commit ist für sich grün.

Closes #259
Refs #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)