### PR TITLE
fix(detail): Folgearbeiten zu den gebündelten Profil-Reads auf den Detail-Seiten

### DIFF
--- a/src/app/pages/championship/championship-detail/championship-detail.page.spec.ts
+++ b/src/app/pages/championship/championship-detail/championship-detail.page.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ChampionshipDetailPage } from "./championship-detail.page";
 import { CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
 import { TranslateModule } from "@ngx-translate/core";
-import { of } from "rxjs";
+import { firstValueFrom, of } from "rxjs";
 import { AuthService } from "src/app/services/auth.service";
 import { FirebaseService } from "src/app/services/firebase.service";
 import { ChampionshipService } from "src/app/services/firebase/championship.service";
@@ -14,20 +14,62 @@ import { ModalController, AlertController, Platform } from "@ionic/angular";
 describe("ChampionshipDetailPage", () => {
   let component: ChampionshipDetailPage;
   let fixture: ComponentFixture<ChampionshipDetailPage>;
+  let fbServiceSpy: jasmine.SpyObj<FirebaseService>;
+  let championshipServiceSpy: jasmine.SpyObj<ChampionshipService>;
+  let userProfileServiceSpy: jasmine.SpyObj<UserProfileService>;
+
+  const mockUser = { uid: "user-1" };
+  const mockGame = { id: "test-game", teamId: "test-team" };
+  const teamMembers = [
+    { id: "user-1", roles: ["captain"] },
+    { id: "member-2", roles: [] },
+  ];
 
   beforeEach(async () => {
-    const fbServiceSpy = jasmine.createSpyObj("FirebaseService", [
+    fbServiceSpy = jasmine.createSpyObj("FirebaseService", [
       "getTeamAdminList",
       "getTeamMemberRefs",
+      "getTeamRef",
       "isTeamAdmin",
     ]);
     fbServiceSpy.getTeamAdminList.and.returnValue(of([]));
+    fbServiceSpy.getTeamRef.and.returnValue(
+      of({ id: "test-team", name: "Team" } as any),
+    );
+    fbServiceSpy.getTeamMemberRefs.and.returnValue(of(teamMembers as any));
+
     const authServiceSpy = jasmine.createSpyObj("AuthService", [
       "getUser$",
       "getAuthenticatedUser$",
     ]);
-    authServiceSpy.getUser$.and.returnValue(of(null));
-    authServiceSpy.getAuthenticatedUser$.and.returnValue(of(null));
+    authServiceSpy.getUser$.and.returnValue(of(mockUser));
+    authServiceSpy.getAuthenticatedUser$.and.returnValue(of(mockUser));
+
+    championshipServiceSpy = jasmine.createSpyObj("ChampionshipService", [
+      "getTeamGameRef",
+      "getTeamGameAttendeesRef",
+    ]);
+    championshipServiceSpy.getTeamGameRef.and.returnValue(of(mockGame as any));
+    championshipServiceSpy.getTeamGameAttendeesRef.and.returnValue(
+      of([{ id: "user-1", status: true }] as any),
+    );
+
+    userProfileServiceSpy = jasmine.createSpyObj("UserProfileService", [
+      "getUserProfileById",
+      "getMemberProfiles",
+      "getChildren",
+    ]);
+    userProfileServiceSpy.getChildren.and.returnValue(of([]));
+    // Same contract as the service: every member comes back with a name.
+    userProfileServiceSpy.getMemberProfiles.and.callFake((members: any[]) =>
+      of(
+        members.map((member) => ({
+          ...member,
+          firstName: "N-" + member.id,
+          lastName: "L",
+        })),
+      ),
+    );
 
     await TestBed.configureTestingModule({
       declarations: [ChampionshipDetailPage],
@@ -36,21 +78,8 @@ describe("ChampionshipDetailPage", () => {
       providers: [
         { provide: AuthService, useValue: authServiceSpy },
         { provide: FirebaseService, useValue: fbServiceSpy },
-        {
-          provide: ChampionshipService,
-          useValue: jasmine.createSpyObj("ChampionshipService", [
-            "getTeamGameRef",
-            "getTeamGameAttendeesRef",
-          ]),
-        },
-        {
-          provide: UserProfileService,
-          useValue: jasmine.createSpyObj("UserProfileService", [
-            "getUserProfileById",
-            "getMemberProfiles",
-            "getChildren",
-          ]),
-        },
+        { provide: ChampionshipService, useValue: championshipServiceSpy },
+        { provide: UserProfileService, useValue: userProfileServiceSpy },
         {
           provide: UiService,
           useValue: jasmine.createSpyObj("UiService", [
@@ -86,11 +115,51 @@ describe("ChampionshipDetailPage", () => {
 
     fixture = TestBed.createComponent(ChampionshipDetailPage);
     component = fixture.componentInstance;
-    component.data = { id: "test-game", teamId: "test-team" } as any;
+    component.data = mockGame as any;
     component.isFuture = true;
   });
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  describe("game$", () => {
+    it("resolves attendees and open members through one batched profile read", async () => {
+      await component.ngOnInit();
+      const game = (await firstValueFrom(component.game$)) as any;
+
+      expect(userProfileServiceSpy.getMemberProfiles).toHaveBeenCalledTimes(1);
+      expect(
+        userProfileServiceSpy.getMemberProfiles.calls.argsFor(0)[0],
+      ).toEqual(teamMembers as any);
+      expect(userProfileServiceSpy.getUserProfileById).not.toHaveBeenCalled();
+
+      expect(game.attendeeListTrue.map((att) => att.id)).toEqual(["user-1"]);
+      expect(game.attendeeListTrue[0].firstName).toBe("N-user-1");
+      // Team roles come from the member document.
+      expect(game.attendeeListTrue[0].roles).toEqual(["captain"]);
+      expect(game.attendeeListFalse).toEqual([]);
+      expect(game.unrespondedMembers.map((member) => member.id)).toEqual([
+        "member-2",
+      ]);
+      expect(game.unrespondedMembers[0].status).toBeNull();
+      // The signed-in user's own row.
+      expect(game.status.length).toBe(1);
+      expect(game.status[0].id).toBe("user-1");
+      expect(game.status[0].status).toBeTrue();
+      expect(game.status[0].firstName).toBe("N-user-1");
+    });
+
+    it("resolves a game without team members instead of staying in the loading state", async () => {
+      fbServiceSpy.getTeamMemberRefs.and.returnValue(of([]));
+      championshipServiceSpy.getTeamGameAttendeesRef.and.returnValue(of([]));
+
+      await component.ngOnInit();
+      const game = (await firstValueFrom(component.game$)) as any;
+
+      expect(game.attendeeListTrue).toEqual([]);
+      expect(game.unrespondedMembers).toEqual([]);
+      expect(game.status).toEqual([]);
+    });
   });
 });

--- a/src/app/pages/championship/championship-detail/championship-detail.page.ts
+++ b/src/app/pages/championship/championship-detail/championship-detail.page.ts
@@ -260,8 +260,8 @@ export class ChampionshipDetailPage implements OnInit {
                                 return {
                                   id: id,
                                   status: attendee?.status ?? null,
-                                  firstName: member?.firstName || "Unknown",
-                                  lastName: member?.lastName || "Unknown",
+                                  firstName: member.firstName,
+                                  lastName: member.lastName,
                                 };
                               });
 
@@ -287,9 +287,9 @@ export class ChampionshipDetailPage implements OnInit {
                               attendees: [],
                               attendeeListTrue: [],
                               attendeeListFalse: [],
-                              unrespondedMembers: teamMembersWithDetails
-                                .filter((member) => member !== null)
-                                .map((member) => ({ ...member, status: null })), // Also ensure 'status: null' here for consistency
+                              unrespondedMembers: teamMembersWithDetails.map(
+                                (member) => ({ ...member, status: null }),
+                              ), // Also ensure 'status: null' here for consistency
                               status: [], // Empty array for status in case of error
                             });
                           }),

--- a/src/app/pages/championship/championship-detail/championship-detail.page.ts
+++ b/src/app/pages/championship/championship-detail/championship-detail.page.ts
@@ -98,6 +98,12 @@ export class ChampionshipDetailPage implements OnInit {
     if (!this.game) {
       return;
     }
+    // Build the streams only once: ngOnInit and ionViewWillEnter both call
+    // this, and rebuilding would drop the batched profile read mid-flight
+    // and issue it again (same guard as on the Helfer detail page).
+    if (this.game$) {
+      return;
+    }
 
     this.game$ = this.getGame(this.game.teamId, this.game.id);
     this.user$ = this.authService.getUser$();

--- a/src/app/pages/event/event-detail/event-detail.page.ts
+++ b/src/app/pages/event/event-detail/event-detail.page.ts
@@ -98,6 +98,12 @@ export class EventDetailPage implements OnInit {
     if (!this.event) {
       return;
     }
+    // Build the streams only once: ngOnInit and ionViewWillEnter both call
+    // this, and rebuilding would drop the batched profile read mid-flight
+    // and issue it again (same guard as on the Helfer detail page).
+    if (this.event$) {
+      return;
+    }
 
     this.event$ = this.getEvent(this.event.clubId, this.event.id);
 

--- a/src/app/pages/event/event-detail/event-detail.page.ts
+++ b/src/app/pages/event/event-detail/event-detail.page.ts
@@ -149,8 +149,7 @@ export class EventDetailPage implements OnInit {
                             const attendeeDetails = attendees
                               .map((attendee) => {
                                 const detail = clubMembersWithDetails.find(
-                                  (member) =>
-                                    member && member.id === attendee.id,
+                                  (member) => member.id === attendee.id,
                                 );
                                 return detail
                                   ? { ...detail, status: attendee.status }
@@ -172,10 +171,7 @@ export class EventDetailPage implements OnInit {
                               attendeeDetails.map((att) => att.id),
                             );
                             const unrespondedMembers = clubMembersWithDetails
-                              .filter(
-                                (member) =>
-                                  member && !respondedIds.has(member.id),
-                              )
+                              .filter((member) => !respondedIds.has(member.id))
                               .sort((a, b) =>
                                 a.firstName.localeCompare(b.firstName),
                               );
@@ -212,7 +208,7 @@ export class EventDetailPage implements OnInit {
                             const orderedStatuses = userIds
                               .filter((id) =>
                                 clubMembersWithDetails.some(
-                                  (member) => member && member.id === id,
+                                  (member) => member.id === id,
                                 ),
                               )
                               .map((id) => {
@@ -220,13 +216,13 @@ export class EventDetailPage implements OnInit {
                                   (att) => att.id === id,
                                 );
                                 const member = clubMembersWithDetails.find(
-                                  (m) => m && m.id === id,
+                                  (m) => m.id === id,
                                 );
                                 return {
                                   id: id,
                                   status: attendee?.status ?? null,
-                                  firstName: member?.firstName || "Unknown",
-                                  lastName: member?.lastName || "Unknown",
+                                  firstName: member.firstName,
+                                  lastName: member.lastName,
                                 };
                               });
 
@@ -249,9 +245,7 @@ export class EventDetailPage implements OnInit {
                               attendees: [],
                               attendeeListTrue: [],
                               attendeeListFalse: [],
-                              unrespondedMembers: clubMembersWithDetails.filter(
-                                (member) => member !== null,
-                              ),
+                              unrespondedMembers: clubMembersWithDetails,
                               status: null,
                             });
                           }),

--- a/src/app/pages/helfer/helfer-detail/helfer-detail.page.spec.ts
+++ b/src/app/pages/helfer/helfer-detail/helfer-detail.page.spec.ts
@@ -8,6 +8,7 @@ import {
 import { CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
 import {
   AlertController,
+  LoadingController,
   ModalController,
   ToastController,
 } from "@ionic/angular";
@@ -43,6 +44,8 @@ describe("HelferDetailPage", () => {
   let modalCtrlSpy: jasmine.SpyObj<ModalController>;
   let toastCtrlSpy: jasmine.SpyObj<ToastController>;
   let alertCtrlSpy: jasmine.SpyObj<AlertController>;
+  let loadingCtrlSpy: jasmine.SpyObj<LoadingController>;
+  let loadingOverlay: { present: jasmine.Spy; dismiss: jasmine.Spy };
 
   const mockUser = { uid: "user-123", email: "test@example.com" };
 
@@ -155,6 +158,12 @@ describe("HelferDetailPage", () => {
       present: jasmine.createSpy("present"),
     } as any);
     alertCtrlSpy = jasmine.createSpyObj("AlertController", ["create"]);
+    loadingOverlay = {
+      present: jasmine.createSpy("present").and.resolveTo(),
+      dismiss: jasmine.createSpy("dismiss").and.resolveTo(),
+    };
+    loadingCtrlSpy = jasmine.createSpyObj("LoadingController", ["create"]);
+    loadingCtrlSpy.create.and.resolveTo(loadingOverlay as any);
 
     TestBed.configureTestingModule({
       declarations: [HelferDetailPage],
@@ -169,6 +178,7 @@ describe("HelferDetailPage", () => {
         { provide: ModalController, useValue: modalCtrlSpy },
         { provide: AlertController, useValue: alertCtrlSpy },
         { provide: ToastController, useValue: toastCtrlSpy },
+        { provide: LoadingController, useValue: loadingCtrlSpy },
       ],
     }).compileComponents();
 
@@ -1058,6 +1068,86 @@ describe("HelferDetailPage", () => {
       } as HelferEvent;
       component.changeTimeFrom({ detail: { value: "20:00" } });
       expect(component.event.timeTo).toBe("20:00");
+    });
+  });
+
+  describe("confirmSchichten", () => {
+    const resolvedSchicht = {
+      ...mockSchicht,
+      attendeeListTrue: [
+        {
+          id: "member-1",
+          firstName: "Anna",
+          lastName: "B",
+          status: true,
+          confirmed: false,
+        },
+      ],
+    };
+
+    beforeEach(() => {
+      component.event = mockHelferEvent as HelferEvent;
+      alertCtrlSpy.create.and.resolveTo({
+        present: jasmine.createSpy("present").and.resolveTo(),
+      } as any);
+    });
+
+    it("offers the unconfirmed attendees from the pinned schichten$ without re-reading", async () => {
+      const readSpy = spyOn(
+        component,
+        "getHelferEventSchichtenWithAttendees",
+      ).and.callThrough();
+      component.schichten$ = of([resolvedSchicht]);
+
+      await component.confirmSchichten();
+
+      expect(readSpy).not.toHaveBeenCalled();
+      const inputs = (alertCtrlSpy.create.calls.mostRecent().args[0] as any)
+        .inputs as any[];
+      expect(inputs.length).toBe(1);
+      expect(inputs[0].value.memberId).toBe("member-1");
+      expect(loadingOverlay.dismiss).toHaveBeenCalled();
+    });
+
+    it("waits until the eager placeholders have been resolved", async () => {
+      const placeholder = {
+        ...mockSchicht,
+        attendeeListTrue: [],
+        pending: true,
+        loadFailed: false,
+      };
+      component.schichten$ = of([placeholder], [resolvedSchicht]);
+
+      await component.confirmSchichten();
+
+      const inputs = (alertCtrlSpy.create.calls.mostRecent().args[0] as any)
+        .inputs as any[];
+      expect(inputs.length).toBe(1);
+    });
+
+    it("dismisses the spinner and shows an error when the Schichten could not be loaded", async () => {
+      spyOn(console, "error");
+      component.schichten$ = of([
+        { ...mockSchicht, pending: true, loadFailed: true },
+      ]);
+
+      await component.confirmSchichten();
+
+      expect(loadingOverlay.dismiss).toHaveBeenCalled();
+      expect(uiServiceSpy.showErrorToast).toHaveBeenCalled();
+      expect(alertCtrlSpy.create).not.toHaveBeenCalled();
+    });
+
+    it("gives up after the timeout instead of blocking the modal", async () => {
+      spyOn(console, "error");
+      component.confirmSchichtenTimeoutMs = 20;
+      component.schichten$ = NEVER;
+
+      await component.confirmSchichten();
+
+      expect(loadingOverlay.dismiss).toHaveBeenCalled();
+      expect(uiServiceSpy.showErrorToast).toHaveBeenCalled();
+      expect(alertCtrlSpy.create).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/pages/helfer/helfer-detail/helfer-detail.page.ts
+++ b/src/app/pages/helfer/helfer-detail/helfer-detail.page.ts
@@ -269,8 +269,7 @@ export class HelferDetailPage implements OnInit, OnDestroy {
                                 const attendeeDetails = attendees
                                   .map((attendee) => {
                                     const detail = clubMembersWithDetails.find(
-                                      (member) =>
-                                        member && member.id === attendee.id,
+                                      (member) => member.id === attendee.id,
                                     );
                                     return detail
                                       ? {
@@ -295,8 +294,7 @@ export class HelferDetailPage implements OnInit, OnDestroy {
                                 );
                                 const unrespondedMembers =
                                   clubMembersWithDetails.filter(
-                                    (member) =>
-                                      member && !respondedIds.has(member.id),
+                                    (member) => !respondedIds.has(member.id),
                                   );
 
                                 return {
@@ -1067,7 +1065,7 @@ export class HelferDetailPage implements OnInit, OnDestroy {
     // Filtere Mitglieder, die bereits in der Schicht sind
     const existingMemberIds = schicht.attendeeListTrue.map((m) => m.id);
     const availableMembers = clubMembers
-      .filter((member) => member && !existingMemberIds.includes(member.id))
+      .filter((member) => !existingMemberIds.includes(member.id))
       .sort((a, b) => a.firstName.localeCompare(b.firstName));
 
     if (availableMembers.length === 0) {

--- a/src/app/pages/helfer/helfer-detail/helfer-detail.page.ts
+++ b/src/app/pages/helfer/helfer-detail/helfer-detail.page.ts
@@ -20,6 +20,7 @@ import {
   Subscription,
   catchError,
   combineLatest,
+  filter,
   firstValueFrom,
   lastValueFrom,
   map,
@@ -29,6 +30,7 @@ import {
   switchMap,
   take,
   tap,
+  timeout,
 } from "rxjs";
 import { Browser } from "@capacitor/browser";
 import { HelferEvent, Schicht } from "src/app/models/event";
@@ -58,6 +60,8 @@ export class HelferDetailPage implements OnInit, OnDestroy {
   event$: Observable<any>;
   schichten$: Observable<any[]>;
   private schichtenSub: Subscription;
+  /** How long confirmSchichten() waits for schichten$ to resolve. */
+  confirmSchichtenTimeoutMs = 10000;
 
   mode = "yes";
 
@@ -408,21 +412,40 @@ export class HelferDetailPage implements OnInit, OnDestroy {
   }
 
   async confirmSchichten() {
-    // Resolving the Schichten with their attendees takes a moment (club
-    // members plus one attendee list per Schicht); show a spinner instead of
-    // a button that seems to do nothing (#259).
+    // schichten$ is pinned for the page's lifetime and already holds the
+    // resolved Schichten with their attendees; re-running the read cascade
+    // here would open every listener a second time. Wait only until the
+    // eager placeholders are gone — never longer than the timeout — so the
+    // spinner (#259) is always dismissed again.
     const loading = await this.loadingController.create({
       message: await lastValueFrom(this.translate.get("common.loading")),
     });
     await loading.present();
+    let schichten: any[];
     try {
-      const schichten = await firstValueFrom(
-        this.getHelferEventSchichtenWithAttendees(
-          this.event.clubId,
-          this.event.id,
+      schichten = await firstValueFrom(
+        this.schichten$.pipe(
+          filter((list) =>
+            list.every((schicht) => !schicht.pending || schicht.loadFailed),
+          ),
+          timeout(this.confirmSchichtenTimeoutMs),
         ),
-      ).finally(() => loading.dismiss());
-
+      );
+      if (schichten.some((schicht) => schicht.loadFailed)) {
+        throw new Error("Schichten could not be loaded");
+      }
+    } catch (error) {
+      console.error("Error in confirmSchichten:", error);
+      await this.uiService.showErrorToast(
+        await lastValueFrom(
+          this.translate.get("common.general__error_occurred"),
+        ),
+      );
+      return;
+    } finally {
+      await loading.dismiss();
+    }
+    try {
       let alertInputs = schichten.reduce((acc, schicht) => {
         const inputs = schicht.attendeeListTrue
           .filter((member) => !member.confirmed && member.status)

--- a/src/app/pages/training/training-detail/training-detail.page.ts
+++ b/src/app/pages/training/training-detail/training-detail.page.ts
@@ -182,8 +182,7 @@ export class TrainingDetailPage implements OnInit {
                             const attendeeDetails = attendees
                               .map((attendee) => {
                                 const detail = teamMembersWithDetails.find(
-                                  (member) =>
-                                    member && member.id === attendee.id,
+                                  (member) => member.id === attendee.id,
                                 );
                                 return detail
                                   ? {
@@ -266,8 +265,8 @@ export class TrainingDetailPage implements OnInit {
                                 return {
                                   id: id,
                                   status: attendee?.status ?? null,
-                                  firstName: member?.firstName || "Unknown",
-                                  lastName: member?.lastName || "Unknown",
+                                  firstName: member.firstName,
+                                  lastName: member.lastName,
                                   changedAt: attendee?.changedAt ?? null,
                                 };
                               });
@@ -294,9 +293,9 @@ export class TrainingDetailPage implements OnInit {
                               attendees: [],
                               attendeeListTrue: [],
                               attendeeListFalse: [],
-                              unrespondedMembers: teamMembersWithDetails
-                                .filter((member) => member !== null)
-                                .map((member) => ({ ...member, status: null })), // Also ensure 'status: null' here for consistency
+                              unrespondedMembers: teamMembersWithDetails.map(
+                                (member) => ({ ...member, status: null }),
+                              ), // Also ensure 'status: null' here for consistency
                               status: [], // Empty array for status in case of error
                             });
                           }),

--- a/src/app/pages/training/training-detail/training-detail.page.ts
+++ b/src/app/pages/training/training-detail/training-detail.page.ts
@@ -108,6 +108,12 @@ export class TrainingDetailPage implements OnInit {
     if (!this.training) {
       return;
     }
+    // Build the streams only once: ngOnInit and ionViewWillEnter both call
+    // this, and rebuilding would drop the batched profile read mid-flight
+    // and issue it again (same guard as on the Helfer detail page).
+    if (this.training$) {
+      return;
+    }
 
     this.training$ = this.getTraining(this.training.teamId, this.training.id);
     this.exerciseList$ = this.exerciseService.getTeamTrainingExerciseRefs(


### PR DESCRIPTION
## Problem

Review-Befunde zu #268 auf den Detail-Seiten:

- Training-, Spiel- und Event-Detail riefen `loadData()` aus `ngOnInit` und `ionViewWillEnter` auf und bauten den Stream zweimal; der erste Profil-Read wurde mitten im Flug verworfen und erneut abgeschickt (doppelte Reads bei Team-Seiten).
- `confirmSchichten()` baute die gesamte Lesekette ein zweites Mal auf, obwohl `schichten$` gepinnt ist, und schloss den Spinner nur im `finally` von `firstValueFrom`. Eine Kette, die nie emittiert, oder ein synchroner Fehler liess das Overlay stehen; die frühere 10-Sekunden-Grenze war mit #268 entfallen.
- `member && …`, `.filter(member !== null)` und `|| "Unknown"` in den Seiten stammten noch aus dem entfernten `catchError(() => of(null))`-Pfad.
- Die Championship-Spec listete `getMemberProfiles` nur als Spy ohne Rückgabewert und rief `ngOnInit` nie auf.

## Änderung

Ein Commit pro Thema:

- Build-once-Sperre in `loadData()` der drei Seiten, wie auf der Helfer-Detail-Seite.
- `confirmSchichten()` wartet auf `schichten$` (bis die Platzhalter weg sind), höchstens zehn Sekunden, schliesst den Spinner in jedem Fall und zeigt bei Fehler oder Timeout einen Toast. Vier neue Tests.
- Tote Null-Prüfungen und doppelte Namens-Fallbacks in den vier Seiten entfernt; der Fallback lebt nur noch im Service.
- Championship-Spec prüft `game$` für Zusagen, offene Mitglieder, eigene Statuszeile und leere Mitgliederliste.

Unabhängig von #270 (Service-Branch), beide Branches gehen von `master` aus.

## Test

`npx ng test --no-watch --browsers=ChromeHeadless`: 242 of 242 SUCCESS. Jeder Commit ist für sich grün.

Refs #268, #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)