### PR TITLE
fix(onboarding): Club-Onboarding nur nach Server-Bestätigung statt bei Offline-Cache

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -3,6 +3,10 @@ import { TestBed } from "@angular/core/testing";
 import { AppComponent } from "./app.component";
 import { TranslateModule } from "@ngx-translate/core";
 import { RouterTestingModule } from "@angular/router/testing";
+import { Router } from "@angular/router";
+import { User } from "@angular/fire/auth";
+import { AlertButton } from "@ionic/angular";
+import { Club } from "./models/club";
 import { of } from "rxjs";
 import { SwUpdate } from "@angular/service-worker";
 import { AuthService } from "./services/auth.service";
@@ -16,16 +20,26 @@ import {
 } from "@ionic/angular";
 
 describe("AppComponent", () => {
+  let fbServiceSpy: jasmine.SpyObj<FirebaseService>;
+  let alertCtrlSpy: jasmine.SpyObj<AlertController>;
+  let alertSpy: jasmine.SpyObj<HTMLIonAlertElement>;
+
   beforeEach(async () => {
     const authServiceSpy = jasmine.createSpyObj("AuthService", ["getUser$"], {
       user$: of(null),
       authState$: of(null),
     });
     authServiceSpy.getUser$.and.returnValue(of(null));
-    const fbServiceSpy = jasmine.createSpyObj("FirebaseService", [
+    fbServiceSpy = jasmine.createSpyObj("FirebaseService", [
       "getClubList",
+      "countClubRefsOnServer",
     ]);
     fbServiceSpy.getClubList.and.returnValue(of([]));
+    fbServiceSpy.countClubRefsOnServer.and.resolveTo(0);
+    alertSpy = jasmine.createSpyObj("HTMLIonAlertElement", ["present"]);
+    alertSpy.present.and.resolveTo();
+    alertCtrlSpy = jasmine.createSpyObj("AlertController", ["create"]);
+    alertCtrlSpy.create.and.resolveTo(alertSpy);
 
     await TestBed.configureTestingModule({
       declarations: [AppComponent],
@@ -65,10 +79,7 @@ describe("AppComponent", () => {
           provide: MenuController,
           useValue: jasmine.createSpyObj("MenuController", ["enable"]),
         },
-        {
-          provide: AlertController,
-          useValue: jasmine.createSpyObj("AlertController", ["create"]),
-        },
+        { provide: AlertController, useValue: alertCtrlSpy },
       ],
     }).compileComponents();
   });
@@ -77,5 +88,79 @@ describe("AppComponent", () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.debugElement.componentInstance;
     expect(app).toBeTruthy();
+  });
+
+  describe("routeByClubList", () => {
+    const user = { uid: "u1" } as User;
+    let app: AppComponent;
+    let router: Router;
+
+    beforeEach(() => {
+      app = TestBed.createComponent(AppComponent).componentInstance;
+      router = TestBed.inject(Router);
+      spyOn(router, "navigateByUrl").and.resolveTo(true);
+    });
+
+    it("shows the offline alert instead of the onboarding when the server is unreachable", async () => {
+      fbServiceSpy.countClubRefsOnServer.and.resolveTo(null);
+
+      await app.routeByClubList(user);
+
+      expect(router.navigateByUrl).not.toHaveBeenCalled();
+      expect(alertCtrlSpy.create).toHaveBeenCalledTimes(1);
+      const options = alertCtrlSpy.create.calls.mostRecent().args[0];
+      expect(options.header).toBe("common.offline");
+      expect(options.buttons.length).toBe(1);
+      expect(alertSpy.present).toHaveBeenCalled();
+    });
+
+    it("re-runs the club check when the retry button is pressed", async () => {
+      fbServiceSpy.countClubRefsOnServer.and.resolveTo(null);
+      await app.routeByClubList(user);
+      const options = alertCtrlSpy.create.calls.mostRecent().args[0];
+      const retryButton = options.buttons[0] as AlertButton;
+
+      fbServiceSpy.countClubRefsOnServer.and.resolveTo(0);
+      retryButton.handler(undefined);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(fbServiceSpy.countClubRefsOnServer).toHaveBeenCalledTimes(2);
+      expect(router.navigateByUrl).toHaveBeenCalledWith("/onboarding-club");
+    });
+
+    it("opens the club onboarding when the server confirms there are no clubs", async () => {
+      fbServiceSpy.countClubRefsOnServer.and.resolveTo(0);
+
+      await app.routeByClubList(user);
+
+      expect(alertCtrlSpy.create).not.toHaveBeenCalled();
+      expect(router.navigateByUrl).toHaveBeenCalledWith("/onboarding-club");
+    });
+
+    it("re-reads the club list once when the cache was stale", async () => {
+      fbServiceSpy.getClubList.and.returnValues(
+        of([]),
+        of([{ id: "c1", subscriptionActive: true } as unknown as Club]),
+      );
+      fbServiceSpy.countClubRefsOnServer.and.resolveTo(1);
+
+      await app.routeByClubList(user);
+
+      expect(fbServiceSpy.getClubList).toHaveBeenCalledTimes(2);
+      expect(alertCtrlSpy.create).not.toHaveBeenCalled();
+      expect(router.navigateByUrl).not.toHaveBeenCalledWith("/onboarding-club");
+    });
+
+    it("skips the server probe when the cache already has clubs", async () => {
+      fbServiceSpy.getClubList.and.returnValue(
+        of([{ id: "c1", subscriptionActive: true } as unknown as Club]),
+      );
+
+      await app.routeByClubList(user);
+
+      expect(fbServiceSpy.countClubRefsOnServer).not.toHaveBeenCalled();
+      expect(router.navigateByUrl).not.toHaveBeenCalledWith("/onboarding-club");
+    });
   });
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -152,63 +152,7 @@ export class AppComponent implements OnInit, AfterViewInit {
           // console.log("E-Mail IS verified. Go ahead..");
           // console.log(user.email, user.displayName, user.emailVerified);
 
-          try {
-            const clubList = await lastValueFrom(
-              this.fbService.getClubList().pipe(take(1)),
-            );
-
-            if (clubList.length === 0) {
-              // console.log("NO! Club Data received. > Call Club Onboarding");
-              try {
-                // Check network status before onboarding
-                // const networkStatus = await Network.getStatus();
-                const navOnboardingClub =
-                  await this.router.navigateByUrl("/onboarding-club");
-                if (navOnboardingClub) {
-                  // console.log("Navigation success to onboarding Club Page");
-                } else {
-                  console.error("Navigation ERROR to onboarding Club Page");
-                }
-              } catch (error) {
-                console.error("Navigation Exception:", error);
-                window.location.reload();
-              }
-            } else {
-              const inactiveClub = clubList.find(
-                (club: any) => club.subscriptionActive === false,
-              );
-
-              if (inactiveClub) {
-                // console.log("NO SUBSCRIPTION FOUND");
-                const modal = await this.modalCtrl.create({
-                  component: ClubSubscriptionPage,
-                  presentingElement: await this.modalCtrl.getTop(),
-                  canDismiss: true,
-                  showBackdrop: true,
-                  componentProps: {
-                    clubId: inactiveClub.id,
-                  },
-                });
-                modal.present();
-
-                const { role } = await modal.onWillDismiss();
-                // console.log(role);
-                if (role === "close" || role === "backdrop") {
-                  this.authService.logout();
-                }
-              } else {
-                // console.log("Club is active");
-
-                const currentPath = this.router.url;
-                if (currentPath === "/login") {
-                  this.menuCtrl.enable(true, "menu");
-                  await this.router.navigateByUrl("/t");
-                }
-              }
-            }
-          } catch (error) {
-            console.error("Error processing club list:", error);
-          }
+          await this.routeByClubList(user);
         }
         // }
 
@@ -760,6 +704,101 @@ export class AppComponent implements OnInit, AfterViewInit {
         console.log("Already on latest version");
       }
     }
+  }
+
+  /**
+   * Decides where a verified user goes after login, based on their club list.
+   *
+   * An empty list is not proof of "no club": with the persistent Firestore
+   * cache, an offline client with an empty cache answers immediately with an
+   * empty snapshot. So before sending the user into the club onboarding, the
+   * club refs are confirmed on the server. If the server is not reachable,
+   * the user stays where they are (the tabs work from cache) and gets an
+   * offline alert with a retry button instead of the onboarding.
+   */
+  async routeByClubList(user: User, retried = false): Promise<void> {
+    try {
+      const clubList = await lastValueFrom(
+        this.fbService.getClubList().pipe(take(1)),
+      );
+
+      if (clubList.length === 0) {
+        const serverCount = await this.fbService.countClubRefsOnServer(
+          user.uid,
+        );
+        if (serverCount === null) {
+          await this.presentAlertOffline(() => this.routeByClubList(user));
+          return;
+        }
+        if (serverCount > 0 && !retried) {
+          // The cache was stale; the server read has refreshed it.
+          await this.routeByClubList(user, true);
+          return;
+        }
+        const navOnboardingClub =
+          await this.router.navigateByUrl("/onboarding-club");
+        if (!navOnboardingClub) {
+          console.error("Navigation ERROR to onboarding Club Page");
+        }
+        return;
+      }
+
+      const inactiveClub = clubList.find(
+        (club: any) => club.subscriptionActive === false,
+      );
+
+      if (inactiveClub) {
+        const modal = await this.modalCtrl.create({
+          component: ClubSubscriptionPage,
+          presentingElement: await this.modalCtrl.getTop(),
+          canDismiss: true,
+          showBackdrop: true,
+          componentProps: {
+            clubId: inactiveClub.id,
+          },
+        });
+        modal.present();
+
+        const { role } = await modal.onWillDismiss();
+        if (role === "close" || role === "backdrop") {
+          this.authService.logout();
+        }
+        return;
+      }
+
+      const currentPath = this.router.url;
+      if (currentPath === "/login") {
+        this.menuCtrl.enable(true, "menu");
+        await this.router.navigateByUrl("/t");
+      }
+    } catch (error) {
+      console.error("Error processing club list:", error);
+    }
+  }
+
+  async presentAlertOffline(retry: () => Promise<void>) {
+    const translations = await Promise.all([
+      lastValueFrom(this.translate.get("common.offline")),
+      lastValueFrom(this.translate.get("common.offline_retry_message")),
+      lastValueFrom(this.translate.get("common.retry")),
+    ]);
+
+    const alert = await this.alertController.create({
+      header: translations[0],
+      message: translations[1],
+      backdropDismiss: false,
+      buttons: [
+        {
+          text: translations[2],
+          role: "confirm",
+          handler: () => {
+            retry();
+          },
+        },
+      ],
+    });
+
+    await alert.present();
   }
 
   async presentAlertSessionExpired() {

--- a/src/app/services/firebase.service.ts
+++ b/src/app/services/firebase.service.ts
@@ -20,6 +20,7 @@ import {
   writeBatch,
   DocumentReference,
   getDocs,
+  getDocsFromServer,
   collectionGroup,
   Timestamp,
 } from "@angular/fire/firestore";
@@ -675,6 +676,39 @@ export class FirebaseService {
     return runInInjectionContext(this.injector, () =>
       docData(clubRef, { idField: "id" }).pipe(shareLatest()),
     ) as unknown as Observable<Club>;
+  }
+
+  /**
+   * Counts the user's own club refs directly on the server, bypassing the
+   * persistent cache. Used to tell "no club" apart from "offline with an empty
+   * cache" before sending the user into the club onboarding.
+   *
+   * @returns the number of club refs, or `null` when the server could not be
+   * reached within `timeoutMs`.
+   */
+  async countClubRefsOnServer(
+    uid: string,
+    timeoutMs = 10000,
+  ): Promise<number | null> {
+    const clubRefList = collection(this.firestore, `userProfile/${uid}/clubs`);
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<null>((resolve) => {
+      timer = setTimeout(() => resolve(null), timeoutMs);
+    });
+    try {
+      const snapshot = await Promise.race([
+        runInInjectionContext(this.injector, () =>
+          getDocsFromServer(clubRefList),
+        ),
+        timeout,
+      ]);
+      return snapshot ? snapshot.size : null;
+    } catch (error) {
+      console.warn("Club refs not reachable on server:", error);
+      return null;
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   getUserClubRefs(user: User): Observable<Club[]> {

--- a/src/assets/lang/de.json
+++ b/src/assets/lang/de.json
@@ -164,6 +164,8 @@
     "app_update_available": "App Update verfügbar",
     "app_update_message": "Eine neue Version {{version}} ist verfügbar. Neue Version laden?",
     "offline": "Du bist offline",
+    "offline_retry_message": "Die Verbindung zum Server ist unterbrochen. Bitte prüfe deine Internetverbindung und versuche es erneut.",
+    "retry": "Erneut versuchen",
     "online": "Du bist online",
     "error__push_notification_not_available": "Push-Benachrichtigung nicht verfügbar",
     "error_device_not_support_push_notifications": "Leider unterstützt Ihr Gerät/Browser keine Push-Benachrichtigungen",

--- a/src/assets/lang/en.json
+++ b/src/assets/lang/en.json
@@ -150,6 +150,8 @@
     "app_update_available": "App update available",
     "app_update_message": "A new version ({{version}}) is available. Would you like to update now?",
     "offline": "You are offline",
+    "offline_retry_message": "The connection to the server was lost. Please check your internet connection and try again.",
+    "retry": "Try again",
     "online": "You are online",
     "error__push_notification_not_available": "Push notification not available",
     "error_device_not_support_push_notifications": "Your device/browser does not support push notifications",

--- a/src/assets/lang/fr.json
+++ b/src/assets/lang/fr.json
@@ -149,6 +149,8 @@
     "app_update_available": "Mise à jour de l'application disponible",
     "app_update_message": "Une nouvelle version ({{version}}) est disponible. Voulez-vous mettre à jour maintenant ?",
     "offline": "Vous êtes hors ligne",
+    "offline_retry_message": "La connexion au serveur est interrompue. Vérifie ta connexion Internet et réessaie.",
+    "retry": "Réessayer",
     "online": "Vous êtes en ligne",
     "error__push_notification_not_available": "Notification push non disponible",
     "error_device_not_support_push_notifications": "Votre appareil/navigateur ne prend pas en charge les notifications push",

--- a/src/assets/lang/it.json
+++ b/src/assets/lang/it.json
@@ -149,6 +149,8 @@
     "app_update_available": "Aggiornamento app disponibile",
     "app_update_message": "È disponibile una nuova versione ({{version}}). Vuoi aggiornare ora?",
     "offline": "Sei offline",
+    "offline_retry_message": "La connessione al server è interrotta. Controlla la tua connessione Internet e riprova.",
+    "retry": "Riprova",
     "online": "Sei online",
     "error__push_notification_not_available": "Notifica push non disponibile",
     "error_device_not_support_push_notifications": "Il tuo dispositivo/browser non supporta le notifiche push",


### PR DESCRIPTION
## Problem

Mehrere Nutzer haben gemeldet, dass bei schlechter Internetverbindung nach dem App-Start das Club-Onboarding erscheint, obwohl sie längst in einem Verein sind.

Ursache: Nach dem Login wurde die Vereinsliste einmal gelesen und eine leere Liste als "kein Verein" gewertet. Mit dem persistenten Firestore-Cache antwortet ein Offline-Client mit leerem Cache (Neuinstallation, nach Logout) aber sofort mit einem leeren Snapshot. Zusätzlich verschluckt `getClubList()` alle Fehler und liefert `[]`.

## Lösung

- **`FirebaseService.countClubRefsOnServer()`** liest die Club-Refs des Nutzers per `getDocsFromServer` am Cache vorbei, mit 10 s Timeout. `null` bedeutet: Server nicht erreichbar.
- **`AppComponent.routeByClubList()`** (ausgelagert aus `ngOnInit`): Eine leere Liste führt nur noch ins Onboarding, wenn der Server das bestätigt. Ist er nicht erreichbar, bleibt der Nutzer auf den Tabs (funktionieren aus dem Cache) und bekommt den Alert "Du bist offline" mit "Erneut versuchen", der die Prüfung wiederholt. Meldet der Server Vereine bei leerem Cache, wird die Liste einmal neu gelesen.
- `window.location.reload()` im Onboarding-Zweig entfernt.
- Übersetzungen `common.offline_retry_message` und `common.retry` in de, fr, it, en.

Bewusst nicht angefasst: `getClubList()` wandelt Fehler weiterhin in `[]` um. Das betrifft alle Aufrufer und gehört in einen eigenen PR.

## Tests

- 5 neue Unit-Tests in `app.component.spec.ts`: offline, Retry-Button, vom Server bestätigt leer, veralteter Cache, Cache hat Vereine. Alle grün in ChromeHeadless.
- Manuell zu prüfen: App nach frischem Login im Flugmodus starten. Erwartet ist der Offline-Alert statt der Vereinsauswahl; nach dem Einschalten des Netzes bringt "Erneut versuchen" direkt weiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
